### PR TITLE
Add ProjectPaymentsSection unit tests

### DIFF
--- a/docs/unit-testing-plan.md
+++ b/docs/unit-testing-plan.md
@@ -39,10 +39,10 @@
 | Core Libraries & Helpers | 13 | 13 | 100% |
 | Services & Data Access | 5 | 5 | 100% |
 | Contexts & Hooks | 24 | 24 | 100% |
-| UI Components & Pages | 7 | 27 | 26% |
+| UI Components & Pages | 8 | 27 | 30% |
 | UI Primitives & Shared Components | 1 | 8 | 13% |
 | Supabase Edge Functions & Automation | 0 | 9 | 0% |
-| **Overall** | **50** | **86** | **58%** |
+| **Overall** | **51** | **86** | **59%** |
 
 ### Core Libraries & Helpers
 | Area | File(s) | What to Cover | Priority | Status | Notes |
@@ -120,7 +120,7 @@
 | Session types settings | `src/components/SessionTypesSection.tsx` | CRUD workflows, default selection, empty states | High | Done | Covered by `src/components/__tests__/SessionTypesSection.test.tsx` (empty state, default toggle, activation toggle, deletion). |
 | Session form fields | `src/components/SessionFormFields.tsx` | Validation messaging, timezone-aware inputs, reminders toggles | Medium | Done | Covered by `src/components/__tests__/SessionFormFields.test.tsx` (project selector + field callbacks). |
 | Session status badge | `src/components/SessionStatusBadge.tsx` | Lifecycle color mapping, accessible labels | Low | Done | Covered by `src/components/__tests__/SessionStatusBadge.test.tsx` (loading badge + editable dropdown updates). |
-| Project payments section | `src/components/ProjectPaymentsSection.tsx` | Summary cards, refresh triggers, empty states | Medium | Not started | Mock `useProjectPayments` to emit various totals. |
+| Project payments section | `src/components/ProjectPaymentsSection.tsx` | Summary cards, refresh triggers, empty states | Medium | Done | Covered by `src/components/__tests__/ProjectPaymentsSection.test.tsx` for metrics, refresh callback, and empty state. |
 | Sessions section surface | `src/components/SessionsSection.tsx` | Tab filtering, sorting integration, quick actions | Medium | Not started | Stub hooks to return sample data + assert CTA availability. |
 | Enhanced sessions section | `src/components/EnhancedSessionsSection.tsx` | Multi-column layout, performance instrumentation | Medium | Not started | Ensure virtualization thresholds + analytics logging. |
 | Unified client details | `src/components/UnifiedClientDetails.tsx` | Conditional rendering of contact info, copy buttons | Low | Not started | Verify fallback text when data missing. |
@@ -208,6 +208,7 @@ _Statuses_: `Not started`, `In progress`, `Blocked`, `Ready for review`, `Done`.
 | 2025-10-25 (midday) | Codex | Added template utilities, payment colors, and project summary builder coverage | `src/lib/templateUtils.test.ts`, `src/lib/paymentColors.test.ts`, and `src/lib/projects/buildProjectSummaryItems.test.tsx` validate helper fallbacks, palette safety, and summary chips/info renders | Revisit when template helpers gain new placeholders or summary chips change |
 | 2025-10-25 (afternoon) | Codex | Added protected route, offline banner, and KPI preset coverage | `src/components/__tests__/ProtectedRoute.test.tsx`, `src/components/__tests__/OfflineBanner.test.tsx`, and `src/components/ui/__tests__/kpi-presets.test.ts` cover loading redirects, connectivity retries, and preset styling contracts | Revisit if onboarding flow or preset catalog changes |
 | 2025-10-25 (late afternoon) | Codex | Added validation helpers, context coverage, and UI prefetch/status fields | `src/lib/validation.test.ts`, `src/contexts/__tests__/AuthContext.test.tsx`, `src/contexts/__tests__/OrganizationContext.test.tsx`, `src/contexts/__tests__/OnboardingContext.test.tsx`, plus `src/components/__tests__/RoutePrefetcher.test.tsx`, `src/components/__tests__/SessionStatusBadge.test.tsx`, and `src/components/__tests__/SessionFormFields.test.tsx` harden schema guards, auth/org onboarding flows, and booking UI surfaces | Revisit when validation, onboarding, or session UI flows expand |
+| 2025-10-26 | Codex | Added ProjectPaymentsSection coverage | `src/components/__tests__/ProjectPaymentsSection.test.tsx` verifies summary cards, empty state, and refresh callback | Continue tackling SessionsSection and EnhancedSessionsSection components |
 
 ## Maintenance Rules of Thumb
 - Treat this file like the single source of truth for unit testing status—update it in the same PR as any test additions or strategy changes.

--- a/src/components/__tests__/ProjectPaymentsSection.test.tsx
+++ b/src/components/__tests__/ProjectPaymentsSection.test.tsx
@@ -1,0 +1,231 @@
+import { render, screen, waitFor, fireEvent } from "@/utils/testUtils";
+import { ProjectPaymentsSection } from "../ProjectPaymentsSection";
+import { mockSupabaseClient } from "@/utils/testUtils";
+import { useToast } from "@/hooks/use-toast";
+import { useFormsTranslation } from "@/hooks/useTypedTranslation";
+
+jest.mock("@/integrations/supabase/client", () => ({
+  supabase: mockSupabaseClient,
+}));
+
+jest.mock("@/hooks/use-toast", () => ({
+  useToast: jest.fn(),
+}));
+
+jest.mock("@/hooks/useTypedTranslation", () => ({
+  useFormsTranslation: jest.fn(),
+}));
+
+jest.mock("../AddPaymentDialog", () => ({
+  AddPaymentDialog: ({ onPaymentAdded }: { onPaymentAdded?: () => void }) => (
+    <button onClick={() => onPaymentAdded?.()} aria-label="trigger-add-payment">
+      add payment
+    </button>
+  ),
+}));
+
+jest.mock("../EditPaymentDialog", () => ({
+  EditPaymentDialog: () => null,
+}));
+
+type MockSupabaseOptions = {
+  project?: Record<string, unknown> | null;
+  payments?: Array<Record<string, unknown>>;
+  services?: Array<Record<string, unknown>>;
+};
+
+const mockUseToast = useToast as jest.Mock;
+const mockUseFormsTranslation = useFormsTranslation as jest.Mock;
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: jest.fn().mockImplementation(() => ({
+      matches: false,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+});
+
+const setupSupabaseFrom = ({
+  project = { id: "project-1", base_price: 500 },
+  payments = [],
+  services = [],
+}: MockSupabaseOptions) => {
+  const selectProject = jest.fn().mockReturnValue({
+    eq: jest.fn().mockReturnValue({
+      single: jest.fn().mockResolvedValue({ data: project, error: null }),
+    }),
+  });
+
+  const paymentsOrderFinal = jest
+    .fn()
+    .mockResolvedValue({ data: payments, error: null });
+  const paymentsOrder = jest.fn().mockReturnValue({ order: paymentsOrderFinal });
+  const selectPayments = jest.fn().mockReturnValue({
+    eq: jest.fn().mockReturnValue({
+      order: paymentsOrder,
+    }),
+  });
+
+  const selectServices = jest.fn().mockReturnValue({
+    eq: jest.fn().mockResolvedValue({ data: services, error: null }),
+  });
+
+  mockSupabaseClient.from.mockImplementation((table: string) => {
+    switch (table) {
+      case "projects":
+        return { select: selectProject };
+      case "payments":
+        return { select: selectPayments };
+      case "project_services":
+        return { select: selectServices };
+      default:
+        return { select: jest.fn() };
+    }
+  });
+
+  return {
+    selectProject,
+    selectPayments,
+    selectServices,
+    paymentsOrder,
+    paymentsOrderFinal,
+  };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockSupabaseClient.from.mockReset();
+  mockSupabaseClient.auth.getUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
+  mockUseToast.mockReturnValue({ toast: jest.fn() });
+  mockUseFormsTranslation.mockReturnValue({ t: (key: string) => key });
+});
+
+describe("ProjectPaymentsSection", () => {
+  it("renders summary metrics based on fetched payments and services", async () => {
+    const payments = [
+      {
+        id: "pay-base",
+        project_id: "project-1",
+        amount: 500,
+        description: null,
+        status: "due",
+        date_paid: null,
+        created_at: "2024-05-01T00:00:00Z",
+        type: "base_price",
+      },
+      {
+        id: "pay-paid",
+        project_id: "project-1",
+        amount: 200,
+        description: "Deposit",
+        status: "paid",
+        date_paid: "2024-05-02T00:00:00Z",
+        created_at: "2024-05-02T00:00:00Z",
+        type: "manual",
+      },
+      {
+        id: "pay-due",
+        project_id: "project-1",
+        amount: 100,
+        description: "Remaining",
+        status: "due",
+        date_paid: null,
+        created_at: "2024-05-03T00:00:00Z",
+        type: "manual",
+      },
+    ];
+
+    setupSupabaseFrom({
+      project: { id: "project-1", base_price: 500 },
+      payments,
+      services: [
+        {
+          services: {
+            id: "service-1",
+            name: "Album",
+            selling_price: 150,
+            extra: true,
+          },
+        },
+      ],
+    });
+
+    render(<ProjectPaymentsSection projectId="project-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("payments.total_paid")).toBeInTheDocument();
+    });
+
+    expect(screen.getAllByText("TRY 200").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("TRY 150").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("TRY 550").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("payments.due").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Deposit").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("payments.base_price_label").length).toBeGreaterThan(0);
+  });
+
+  it("shows empty state when project has no payments and no base price", async () => {
+    setupSupabaseFrom({
+      project: { id: "project-1", base_price: 0 },
+      payments: [],
+      services: [],
+    });
+
+    render(<ProjectPaymentsSection projectId="project-1" />);
+
+    await waitFor(() => {
+      expect(mockSupabaseClient.from).toHaveBeenCalledWith("payments");
+    });
+
+    expect(screen.getByText("payments.no_payments")).toBeInTheDocument();
+  });
+
+  it("refreshes payments and notifies parent when a new payment is added", async () => {
+    const onPaymentsUpdated = jest.fn();
+    const payments = [
+      {
+        id: "pay-base",
+        project_id: "project-1",
+        amount: 500,
+        description: null,
+        status: "due",
+        date_paid: null,
+        created_at: "2024-05-01T00:00:00Z",
+        type: "base_price",
+      },
+    ];
+
+    setupSupabaseFrom({
+      project: { id: "project-1", base_price: 500 },
+      payments,
+      services: [],
+    });
+
+    render(<ProjectPaymentsSection projectId="project-1" onPaymentsUpdated={onPaymentsUpdated} />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("trigger-add-payment")).toBeInTheDocument();
+    });
+
+    mockSupabaseClient.from.mockClear();
+    setupSupabaseFrom({
+      project: { id: "project-1", base_price: 500 },
+      payments,
+      services: [],
+    });
+
+    fireEvent.click(screen.getByLabelText("trigger-add-payment"));
+
+    await waitFor(() => {
+      expect(onPaymentsUpdated).toHaveBeenCalled();
+    });
+
+    expect(mockSupabaseClient.from).toHaveBeenCalledWith("payments");
+  });
+});


### PR DESCRIPTION
## Summary
- add a Jest suite for `ProjectPaymentsSection` covering summary metrics, empty state, and refresh callback flows
- mock Supabase queries, translation hooks, and child dialogs to exercise the component behavior deterministically
- update `docs/unit-testing-plan.md` progress snapshot, inventory status, and iteration log for the completed ProjectPaymentsSection tests

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68fc86f59060832197d359e018f8df62