### PR TITLE
Add SessionsSection unit tests

### DIFF
--- a/docs/unit-testing-plan.md
+++ b/docs/unit-testing-plan.md
@@ -39,10 +39,10 @@
 | Core Libraries & Helpers | 13 | 13 | 100% |
 | Services & Data Access | 5 | 5 | 100% |
 | Contexts & Hooks | 24 | 24 | 100% |
-| UI Components & Pages | 8 | 27 | 30% |
+| UI Components & Pages | 9 | 27 | 33% |
 | UI Primitives & Shared Components | 1 | 8 | 13% |
 | Supabase Edge Functions & Automation | 0 | 9 | 0% |
-| **Overall** | **51** | **86** | **59%** |
+| **Overall** | **52** | **86** | **60%** |
 
 ### Core Libraries & Helpers
 | Area | File(s) | What to Cover | Priority | Status | Notes |
@@ -210,6 +210,7 @@ _Statuses_: `Not started`, `In progress`, `Blocked`, `Ready for review`, `Done`.
 | 2025-10-25 (late afternoon) | Codex | Added validation helpers, context coverage, and UI prefetch/status fields | `src/lib/validation.test.ts`, `src/contexts/__tests__/AuthContext.test.tsx`, `src/contexts/__tests__/OrganizationContext.test.tsx`, `src/contexts/__tests__/OnboardingContext.test.tsx`, plus `src/components/__tests__/RoutePrefetcher.test.tsx`, `src/components/__tests__/SessionStatusBadge.test.tsx`, and `src/components/__tests__/SessionFormFields.test.tsx` harden schema guards, auth/org onboarding flows, and booking UI surfaces | Revisit when validation, onboarding, or session UI flows expand |
 | 2025-10-26 | Codex | Added ProjectPaymentsSection coverage | `src/components/__tests__/ProjectPaymentsSection.test.tsx` verifies summary cards, empty state, and refresh callback | Continue tackling SessionsSection and EnhancedSessionsSection components |
 | 2025-10-26 (later) | Codex | Reconciled Contexts/Hooks snapshot with remaining gaps | Updated progress table to show TemplateBuilder hook still pending | Add tests for `useTemplateBuilder` hook |
+| 2025-10-26 (even later) | Codex | Added SessionsSection coverage | `src/components/__tests__/SessionsSection.test.tsx` ensures loading skeleton, empty state messaging, and sheet interactions | Next: Extend coverage to EnhancedSessionsSection flows |
 
 ## Maintenance Rules of Thumb
 - Treat this file like the single source of truth for unit testing status—update it in the same PR as any test additions or strategy changes.

--- a/src/components/__tests__/SessionsSection.test.tsx
+++ b/src/components/__tests__/SessionsSection.test.tsx
@@ -1,0 +1,231 @@
+import { fireEvent, render, screen } from "@/utils/testUtils";
+import { SessionsSection } from "../SessionsSection";
+import { sortSessionsByLifecycle } from "@/lib/sessionSorting";
+import { useFormsTranslation } from "@/hooks/useTypedTranslation";
+import { useNavigate, useLocation } from "react-router-dom";
+
+type Session = Parameters<typeof SessionsSection>[0]["sessions"][number];
+
+jest.mock("@/lib/sessionSorting", () => ({
+  sortSessionsByLifecycle: jest.fn(),
+}));
+
+jest.mock("@/hooks/useTypedTranslation", () => ({
+  useFormsTranslation: jest.fn(),
+}));
+
+const mockNavigate = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  ...(jest.requireActual("react-router-dom") as Record<string, unknown>),
+  useNavigate: jest.fn(),
+  useLocation: jest.fn(),
+}));
+
+const mockDeadSimpleSessionBanner = jest.fn(
+  ({ session, onClick }: { session: Session; onClick: () => void }) => (
+    <button data-testid={`session-banner-${session.id}`} onClick={onClick}>
+      banner-{session.id}
+    </button>
+  )
+);
+
+jest.mock("../DeadSimpleSessionBanner", () => ({
+  __esModule: true,
+  default: (props: { session: Session; onClick: () => void }) =>
+    mockDeadSimpleSessionBanner(props),
+}));
+
+const mockNewSessionDialogForProject = jest.fn(
+  ({ onSessionScheduled }: { onSessionScheduled: () => void }) => (
+    <button data-testid="new-session-dialog" onClick={onSessionScheduled}>
+      schedule-session
+    </button>
+  )
+);
+
+jest.mock("../NewSessionDialogForProject", () => ({
+  NewSessionDialogForProject: (props: { onSessionScheduled: () => void }) =>
+    mockNewSessionDialogForProject(props),
+}));
+
+const mockEditSessionDialog = jest.fn(() => null);
+
+jest.mock("../EditSessionDialog", () => ({
+  __esModule: true,
+  default: () => mockEditSessionDialog(),
+}));
+
+const mockSessionSheetView = jest.fn(
+  ({
+    isOpen,
+    onOpenChange,
+    onViewFullDetails,
+    onSessionUpdated,
+  }: {
+    isOpen: boolean;
+    onOpenChange: (open: boolean) => void;
+    onViewFullDetails: () => void;
+    onSessionUpdated: () => void;
+  }) => (
+    <div data-testid="session-sheet-view" data-open={isOpen}>
+      <button onClick={() => onOpenChange(false)}>close-sheet</button>
+      <button onClick={onViewFullDetails}>view-details</button>
+      <button onClick={onSessionUpdated}>sheet-updated</button>
+    </div>
+  )
+);
+
+jest.mock("../SessionSheetView", () => ({
+  __esModule: true,
+  default: (props: {
+    isOpen: boolean;
+    onOpenChange: (open: boolean) => void;
+    onViewFullDetails: () => void;
+    onSessionUpdated: () => void;
+  }) => mockSessionSheetView(props),
+}));
+
+const mockSortSessionsByLifecycle = sortSessionsByLifecycle as jest.Mock;
+const mockUseFormsTranslation = useFormsTranslation as jest.Mock;
+const mockUseNavigate = useNavigate as jest.Mock;
+const mockUseLocation = useLocation as jest.Mock;
+
+const baseSession: Session = {
+  id: "session-1",
+  lead_id: "lead-1",
+  project_id: "project-1",
+  status: "scheduled",
+  session_time: "10:00",
+  session_date: "2025-01-01",
+  notes: "",
+  created_at: "2025-01-01T00:00:00Z",
+  updated_at: "2025-01-01T00:00:00Z",
+};
+
+describe("SessionsSection", () => {
+  const onSessionUpdated = jest.fn();
+  const onDeleteSession = jest.fn();
+
+  beforeEach(() => {
+    mockSortSessionsByLifecycle.mockReset();
+    mockUseFormsTranslation.mockReturnValue({
+      t: (key: string, options?: Record<string, unknown>) =>
+        options?.count ? `${key}:${options.count}` : key,
+    });
+    mockUseNavigate.mockReturnValue(mockNavigate);
+    mockUseLocation.mockReturnValue({
+      pathname: "/projects/abc",
+      search: "",
+      hash: "",
+    });
+    mockDeadSimpleSessionBanner.mockClear();
+    mockNewSessionDialogForProject.mockClear();
+    mockSessionSheetView.mockClear();
+    mockNavigate.mockClear();
+    onSessionUpdated.mockClear();
+    onDeleteSession.mockClear();
+  });
+
+  beforeAll(() => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: jest.fn().mockImplementation(() => ({
+        matches: false,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
+  });
+
+  it("renders loading skeleton when loading is true", () => {
+    const { container } = render(
+      <SessionsSection
+        sessions={[]}
+        loading
+        leadId="lead-1"
+        projectId="project-1"
+        leadName="Lead"
+        projectName="Project"
+        onSessionUpdated={onSessionUpdated}
+        onDeleteSession={onDeleteSession}
+      />
+    );
+
+    expect(screen.getByText("sessions_form.title")).toBeInTheDocument();
+    expect(container.querySelectorAll(".animate-pulse")).not.toHaveLength(0);
+    expect(mockNewSessionDialogForProject).not.toHaveBeenCalled();
+  });
+
+  it("renders empty state when no sessions exist", () => {
+    mockSortSessionsByLifecycle.mockReturnValue([]);
+
+    render(
+      <SessionsSection
+        sessions={[]}
+        loading={false}
+        leadId="lead-1"
+        projectId="project-1"
+        leadName="Lead"
+        projectName="Project"
+        onSessionUpdated={onSessionUpdated}
+        onDeleteSession={onDeleteSession}
+      />
+    );
+
+    expect(mockNewSessionDialogForProject).toHaveBeenCalledWith(
+      expect.objectContaining({ onSessionScheduled: expect.any(Function) })
+    );
+    expect(screen.getByText("sessions_form.no_sessions")).toBeInTheDocument();
+    expect(screen.getByText("sessions_form.add_sessions_hint")).toBeInTheDocument();
+  });
+
+  it("renders sessions and wires interactions", () => {
+    const sessions: Session[] = [
+      { ...baseSession, id: "session-1", session_name: "Kickoff" },
+      { ...baseSession, id: "session-2", session_name: "Wrap" },
+    ];
+    mockSortSessionsByLifecycle.mockReturnValue([
+      sessions[1],
+      sessions[0],
+    ]);
+
+    render(
+      <SessionsSection
+        sessions={sessions}
+        loading={false}
+        leadId="lead-1"
+        projectId="project-1"
+        leadName="Lead"
+        projectName="Project"
+        onSessionUpdated={onSessionUpdated}
+        onDeleteSession={onDeleteSession}
+      />
+    );
+
+    expect(mockSortSessionsByLifecycle).toHaveBeenCalledWith(sessions);
+    const bannerButtons = [
+      screen.getByTestId("session-banner-session-2"),
+      screen.getByTestId("session-banner-session-1"),
+    ];
+    expect(bannerButtons[0]).toBeInTheDocument();
+
+    fireEvent.click(bannerButtons[0]);
+    const sheet = screen.getByTestId("session-sheet-view");
+    expect(sheet).toHaveAttribute("data-open", "true");
+
+    fireEvent.click(screen.getByText("view-details"));
+    expect(mockNavigate).toHaveBeenCalledWith("/sessions/session-2", {
+      state: { from: "/projects/abc" },
+    });
+
+    fireEvent.click(screen.getByText("sheet-updated"));
+    expect(onSessionUpdated).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByText("close-sheet"));
+    expect(onSessionUpdated).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add targeted unit tests for SessionsSection covering loading, empty state, and sheet interactions
- refresh docs/unit-testing-plan.md progress snapshot and iteration log with the new coverage

## Testing
- `npm test -- SessionsSection`


------
https://chatgpt.com/codex/tasks/task_e_68fc8bf6c3448321adf1272e5a6b8c19