### PR TITLE
Add EnhancedSessionsSection tests and refresh unit plan

### DIFF
--- a/docs/unit-testing-plan.md
+++ b/docs/unit-testing-plan.md
@@ -39,10 +39,10 @@
 | Core Libraries & Helpers | 13 | 13 | 100% |
 | Services & Data Access | 5 | 5 | 100% |
 | Contexts & Hooks | 24 | 24 | 100% |
-| UI Components & Pages | 10 | 27 | 37% |
+| UI Components & Pages | 11 | 27 | 41% |
 | UI Primitives & Shared Components | 1 | 8 | 13% |
 | Supabase Edge Functions & Automation | 0 | 9 | 0% |
-| **Overall** | **53** | **86** | **62%** |
+| **Overall** | **54** | **86** | **63%** |
 
 ### Core Libraries & Helpers
 | Area | File(s) | What to Cover | Priority | Status | Notes |
@@ -122,7 +122,7 @@
 | Session status badge | `src/components/SessionStatusBadge.tsx` | Lifecycle color mapping, accessible labels | Low | Done | Covered by `src/components/__tests__/SessionStatusBadge.test.tsx` (loading badge + editable dropdown updates). |
 | Project payments section | `src/components/ProjectPaymentsSection.tsx` | Summary cards, refresh triggers, empty states | Medium | Done | Covered by `src/components/__tests__/ProjectPaymentsSection.test.tsx` for metrics, refresh callback, and empty state. |
 | Sessions section surface | `src/components/SessionsSection.tsx` | Tab filtering, sorting integration, quick actions | Medium | Not started | Stub hooks to return sample data + assert CTA availability. |
-| Enhanced sessions section | `src/components/EnhancedSessionsSection.tsx` | Multi-column layout, performance instrumentation | Medium | Not started | Ensure virtualization thresholds + analytics logging. |
+| Enhanced sessions section | `src/components/EnhancedSessionsSection.tsx` | Multi-column layout, performance instrumentation | Medium | Done | Covered by `src/components/__tests__/EnhancedSessionsSection.test.tsx` verifying lifecycle sorting, count badge, and click wiring. |
 | Unified client details | `src/components/UnifiedClientDetails.tsx` | Conditional rendering of contact info, copy buttons | Low | Not started | Verify fallback text when data missing. |
 | Project sheet view | `src/components/ProjectSheetView.tsx` | Printable layout, localization of labels, totals | Medium | Not started | Snapshot layout with English/Turkish translations. |
 | Onboarding modal | `src/components/OnboardingModal.tsx` | Step transitions, skip behavior, analytics events | Medium | Not started | Mock context + ensure stage transitions call hooks. |
@@ -211,6 +211,7 @@ _Statuses_: `Not started`, `In progress`, `Blocked`, `Ready for review`, `Done`.
 | 2025-10-26 | Codex | Added ProjectPaymentsSection coverage | `src/components/__tests__/ProjectPaymentsSection.test.tsx` verifies summary cards, empty state, and refresh callback | Continue tackling SessionsSection and EnhancedSessionsSection components |
 | 2025-10-26 (later) | Codex | Reconciled Contexts/Hooks snapshot with remaining gaps | Updated progress table to show TemplateBuilder hook still pending | Add tests for `useTemplateBuilder` hook |
 | 2025-10-26 (even later) | Codex | Added SessionsSection coverage | `src/components/__tests__/SessionsSection.test.tsx` ensures loading skeleton, empty state messaging, and sheet interactions | Next: Extend coverage to EnhancedSessionsSection flows |
+| 2025-10-26 (night) | Codex | Added EnhancedSessionsSection coverage | `src/components/__tests__/EnhancedSessionsSection.test.tsx` verifies lifecycle sorting order, count badge rendering, and banner click wiring | Next: Monitor virtualization thresholds or analytics hooks if they land |
 
 ## Maintenance Rules of Thumb
 - Treat this file like the single source of truth for unit testing status—update it in the same PR as any test additions or strategy changes.

--- a/src/components/__tests__/EnhancedSessionsSection.test.tsx
+++ b/src/components/__tests__/EnhancedSessionsSection.test.tsx
@@ -1,0 +1,126 @@
+import { fireEvent, render, screen } from "@/utils/testUtils";
+import EnhancedSessionsSection from "../EnhancedSessionsSection";
+import { sortSessionsByLifecycle } from "@/lib/sessionSorting";
+import { useFormsTranslation } from "@/hooks/useTypedTranslation";
+
+type Session = Parameters<typeof EnhancedSessionsSection>[0]["sessions"][number];
+
+jest.mock("@/lib/sessionSorting", () => ({
+  sortSessionsByLifecycle: jest.fn(),
+}));
+
+jest.mock("@/hooks/useTypedTranslation", () => ({
+  useFormsTranslation: jest.fn(),
+}));
+
+const mockDeadSimpleSessionBanner = jest.fn(
+  ({ session, onClick }: { session: Session; onClick: (sessionId: string) => void }) => (
+    <button data-testid={`session-${session.id}`} onClick={() => onClick(session.id)}>
+      banner-{session.id}
+    </button>
+  )
+);
+
+jest.mock("../DeadSimpleSessionBanner", () => ({
+  __esModule: true,
+  default: (props: { session: Session; onClick: (sessionId: string) => void }) =>
+    mockDeadSimpleSessionBanner(props),
+}));
+
+const mockSortSessionsByLifecycle = sortSessionsByLifecycle as jest.Mock;
+const mockUseFormsTranslation = useFormsTranslation as jest.Mock;
+
+describe("EnhancedSessionsSection", () => {
+  const baseSession: Session = {
+    id: "session-1",
+    lead_id: "lead-1",
+    project_id: "project-1",
+    status: "planned",
+    session_date: "2025-01-01",
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+  } as Session;
+
+  beforeAll(() => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: jest.fn().mockImplementation(() => ({
+        matches: false,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
+  });
+
+  beforeEach(() => {
+    mockSortSessionsByLifecycle.mockReset();
+    mockDeadSimpleSessionBanner.mockClear();
+    mockUseFormsTranslation.mockReturnValue({
+      t: (key: string) => key,
+    });
+  });
+
+  it("renders loading skeleton when loading is true", () => {
+    const { container } = render(
+      <EnhancedSessionsSection
+        sessions={[]}
+        loading
+        onSessionClick={jest.fn()}
+      />
+    );
+
+    expect(container.querySelector(".animate-pulse")).not.toBeNull();
+    expect(mockDeadSimpleSessionBanner).not.toHaveBeenCalled();
+  });
+
+  it("renders nothing when there are no sessions", () => {
+    const { container } = render(
+      <EnhancedSessionsSection
+        sessions={[]}
+        loading={false}
+        onSessionClick={jest.fn()}
+      />
+    );
+
+    expect(screen.queryByText("sessions_form.title")).not.toBeInTheDocument();
+    expect(container.querySelector("[data-testid^='session-']")).toBeNull();
+    expect(mockSortSessionsByLifecycle).not.toHaveBeenCalled();
+    expect(mockDeadSimpleSessionBanner).not.toHaveBeenCalled();
+  });
+
+  it("renders sorted sessions with count badge and click wiring", () => {
+    const onSessionClick = jest.fn();
+    const sessions: Session[] = [
+      { ...baseSession, id: "session-1", session_name: "First" },
+      { ...baseSession, id: "session-2", session_name: "Second" },
+    ];
+    const sorted: Session[] = [sessions[1], sessions[0]];
+    mockSortSessionsByLifecycle.mockReturnValue(sorted);
+
+    render(
+      <EnhancedSessionsSection
+        sessions={sessions}
+        loading={false}
+        onSessionClick={onSessionClick}
+      />
+    );
+
+    expect(mockSortSessionsByLifecycle).toHaveBeenCalledWith(sessions);
+    expect(screen.getByText("sessions_form.title")).toBeInTheDocument();
+    expect(screen.getByText(String(sessions.length))).toBeInTheDocument();
+    expect(mockDeadSimpleSessionBanner).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ session: sorted[0], onClick: onSessionClick })
+    );
+    expect(mockDeadSimpleSessionBanner).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ session: sorted[1], onClick: onSessionClick })
+    );
+
+    fireEvent.click(screen.getByTestId("session-session-2"));
+    expect(onSessionClick).toHaveBeenCalledWith("session-2");
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for EnhancedSessionsSection covering loading, empty, and lifecycle-sorted render paths
- update the unit-testing plan progress snapshot, inventory entry, and iteration log for the new coverage

## Testing
- npm test -- --runTestsByPath src/components/__tests__/EnhancedSessionsSection.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68fc8eb15e208321b226efb17d9934ff