### PR TITLE
Add coverage for EnhancedProjectDialog reset flows

### DIFF
--- a/docs/unit-testing-plan.md
+++ b/docs/unit-testing-plan.md
@@ -39,10 +39,10 @@
 | Core Libraries & Helpers | 13 | 13 | 100% |
 | Services & Data Access | 5 | 5 | 100% |
 | Contexts & Hooks | 24 | 24 | 100% |
-| UI Components & Pages | 12 | 27 | 44% |
+| UI Components & Pages | 13 | 27 | 48% |
 | UI Primitives & Shared Components | 1 | 8 | 13% |
 | Supabase Edge Functions & Automation | 0 | 9 | 0% |
-| **Overall** | **55** | **86** | **64%** |
+| **Overall** | **56** | **86** | **65%** |
 
 ### Core Libraries & Helpers
 | Area | File(s) | What to Cover | Priority | Status | Notes |
@@ -103,7 +103,7 @@
 | --- | --- | --- | --- | --- | --- |
 | Enhanced lead creation | `src/components/EnhancedAddLeadDialog.tsx` | Dynamic schema init, default status lookup, save pipeline | High | Done | Covered by `src/components/__tests__/EnhancedAddLeadDialog.test.tsx` verifying default status creation, value persistence, and navigation guard. |
 | Enhanced lead edit | `src/components/EnhancedEditLeadDialog.tsx` | Prefill logic, change detection, update mutation flow | High | Done | Covered by `src/components/__tests__/EnhancedEditLeadDialog.test.tsx` for prefill, validation, and Supabase updates. |
-| Enhanced project dialog | `src/components/EnhancedProjectDialog.tsx` | Cross-entity linking, lead selection, Supabase upserts | High | Not started | Validate state reset on close/open cycles. |
+| Enhanced project dialog | `src/components/EnhancedProjectDialog.tsx` | Cross-entity linking, lead selection, Supabase upserts | High | Done | Covered by `src/components/__tests__/EnhancedProjectDialog.test.tsx` ensuring data fetch, custom setup, and close/reopen resets. |
 | Session scheduling dialog | `src/components/ScheduleSessionDialog.tsx` | Prefill data, reminder scheduling hooks, status updates | High | Done | Covered via `src/components/__tests__/ScheduleSessionDialog.test.tsx` & `SessionSchedulingSheet.test.tsx`. |
 | Session scheduling sheet | `src/components/SessionSchedulingSheet.tsx` | Mobile sheet state, timezone-aware slots, submission flow | Medium | Not started | Simulate slot selection + validation toasts. |
 | Project Kanban board | `src/components/ProjectKanbanBoard.tsx` | Drag/drop ordering, status filtering, performance memoization | Medium | Not started | Use DnD testing helpers; ensure optimistic UI reverts on error. |
@@ -213,6 +213,7 @@ _Statuses_: `Not started`, `In progress`, `Blocked`, `Ready for review`, `Done`.
 | 2025-10-26 (even later) | Codex | Added SessionsSection coverage | `src/components/__tests__/SessionsSection.test.tsx` ensures loading skeleton, empty state messaging, and sheet interactions | Next: Extend coverage to EnhancedSessionsSection flows |
 | 2025-10-26 (night) | Codex | Added EnhancedSessionsSection coverage | `src/components/__tests__/EnhancedSessionsSection.test.tsx` verifies lifecycle sorting order, count badge rendering, and banner click wiring | Next: Monitor virtualization thresholds or analytics hooks if they land |
 | 2025-10-26 (late night+) | Codex | Added Enhanced lead edit dialog coverage | `src/components/__tests__/EnhancedEditLeadDialog.test.tsx` exercises prefill, dirty-state detection, validation errors, and Supabase update success toasts | Revisit when dynamic field schema or toast messaging changes |
+| 2025-10-26 (early dawn) | Codex | Added EnhancedProjectDialog coverage | `src/components/__tests__/EnhancedProjectDialog.test.tsx` loads defaults and verifies cancel-driven reset flows | Monitor if project dialog gains new pricing or lead workflows |
 
 ## Maintenance Rules of Thumb
 - Treat this file like the single source of truth for unit testing status—update it in the same PR as any test additions or strategy changes.

--- a/src/components/__tests__/EnhancedProjectDialog.test.tsx
+++ b/src/components/__tests__/EnhancedProjectDialog.test.tsx
@@ -1,0 +1,277 @@
+import userEvent from "@testing-library/user-event";
+import { render, screen, waitFor } from "@testing-library/react";
+import { EnhancedProjectDialog } from "../EnhancedProjectDialog";
+
+const toastSpy = jest.fn();
+
+jest.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({
+    toast: toastSpy,
+  }),
+}));
+
+jest.mock("@/contexts/ProfileContext", () => ({
+  useProfile: () => ({ profile: { id: "profile-1" } }),
+}));
+
+jest.mock("@/contexts/OnboardingContext", () => ({
+  useOnboarding: () => ({
+    currentStep: 3,
+    shouldLockNavigation: false,
+    completeCurrentStep: jest.fn(),
+  }),
+}));
+
+jest.mock("@/hooks/useNotificationTriggers", () => ({
+  useNotificationTriggers: () => ({
+    triggerProjectMilestone: jest.fn(),
+  }),
+}));
+
+jest.mock("@/contexts/OrganizationContext", () => ({
+  useOrganization: () => ({
+    activeOrganization: { id: "org-1" },
+  }),
+}));
+
+const handleModalCloseMock = jest.fn(() => true);
+
+jest.mock("@/hooks/useModalNavigation", () => ({
+  useModalNavigation: jest.fn(() => ({
+    showGuard: false,
+    message: "",
+    handleModalClose: handleModalCloseMock,
+    handleDiscardChanges: jest.fn(),
+    handleStayOnModal: jest.fn(),
+    handleSaveAndExit: jest.fn(),
+  })),
+}));
+
+jest.mock("@/components/settings/NavigationGuardDialog", () => ({
+  NavigationGuardDialog: () => null,
+}));
+
+jest.mock("../LeadStatusBadge", () => ({
+  LeadStatusBadge: ({ leadId }: { leadId: string }) => (
+    <span data-testid={`lead-status-${leadId}`}>status</span>
+  ),
+}));
+
+jest.mock("../ServicePicker", () => ({
+  ServicePicker: ({ onSelectionChange }: any) => (
+    <div>
+      <button onClick={() => onSelectionChange(["svc-1"])}>select-service</button>
+    </div>
+  ),
+}));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const getUserOrganizationIdMock = jest.fn(async () => "org-1");
+
+jest.mock("@/lib/organizationUtils", () => ({
+  getUserOrganizationId: () => getUserOrganizationIdMock(),
+}));
+
+jest.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    auth: { getUser: jest.fn() },
+    from: jest.fn(),
+    rpc: jest.fn(),
+  },
+}));
+
+const { supabase: mockSupabase } = jest.requireMock("@/integrations/supabase/client");
+
+jest.mock("@/components/ui/app-sheet-modal", () => ({
+  AppSheetModal: ({
+    title,
+    isOpen,
+    onOpenChange,
+    footerActions = [],
+    onDirtyClose,
+    dirty,
+    children,
+  }: any) => {
+    if (!isOpen) return null;
+    return (
+      <div data-testid="enhanced-project-dialog">
+        <h1>{title}</h1>
+        <button onClick={() => onDirtyClose?.()} disabled={!dirty}>
+          trigger-dirty-close
+        </button>
+        {children}
+        {footerActions.map((action: any, index: number) => (
+          <button
+            key={index}
+            onClick={action.onClick}
+            disabled={action.disabled}
+          >
+            {action.label}
+          </button>
+        ))}
+        <button onClick={() => onOpenChange(false)}>close-modal</button>
+      </div>
+    );
+  },
+}));
+
+const leadsResponse = [
+  { id: "lead-1", name: "Alice", email: null, phone: null, status: "new" },
+  { id: "lead-2", name: "Bob", email: null, phone: null, status: "contacted" },
+];
+
+const packagesResponse = [
+  {
+    id: "pkg-1",
+    name: "Starter",
+    description: "Basic package",
+    price: 250,
+    applicable_types: ["Wedding"],
+    default_add_ons: ["svc-1"],
+    is_active: true,
+  },
+];
+
+const projectTypesResponse = [
+  { id: "type-1", name: "Wedding", is_default: true },
+  { id: "type-2", name: "Portrait", is_default: false },
+];
+
+const servicesResponse = [
+  { id: "svc-1", name: "Album", category: "Extras", selling_price: 150 },
+];
+
+const createLeadsQuery = () => {
+  const query: any = {
+    select: jest.fn(() => query),
+    eq: jest.fn(() => query),
+    neq: jest.fn(() => query),
+    order: jest.fn(() => Promise.resolve({ data: leadsResponse, error: null })),
+  };
+  return query;
+};
+
+const createPackagesQuery = () => {
+  const query: any = {
+    select: jest.fn(() => query),
+    eq: jest.fn(() => query),
+    order: jest.fn(() => Promise.resolve({ data: packagesResponse, error: null })),
+  };
+  return query;
+};
+
+const createProjectTypesQuery = () => {
+  const query: any = {
+    select: jest.fn(() => query),
+    eq: jest.fn(() => query),
+    order: jest.fn(() => Promise.resolve({ data: projectTypesResponse, error: null })),
+  };
+  return query;
+};
+
+const createServicesQuery = () => {
+  let orderCallCount = 0;
+  const query: any = {
+    select: jest.fn(() => query),
+    eq: jest.fn(() => query),
+    order: jest.fn(() => {
+      orderCallCount += 1;
+      if (orderCallCount < 2) {
+        return query;
+      }
+      return Promise.resolve({ data: servicesResponse, error: null });
+    }),
+  };
+  return query;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  handleModalCloseMock.mockReturnValue(true);
+  getUserOrganizationIdMock.mockClear();
+  getUserOrganizationIdMock.mockResolvedValue("org-1");
+
+  mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
+  mockSupabase.rpc.mockResolvedValue({ data: "status-1", error: null });
+  mockSupabase.from.mockImplementation((table: string) => {
+    switch (table) {
+      case "leads":
+        return createLeadsQuery();
+      case "packages":
+        return createPackagesQuery();
+      case "project_types":
+        return createProjectTypesQuery();
+      case "services":
+        return createServicesQuery();
+      default:
+        return {
+          select: jest.fn(() => ({ eq: jest.fn(() => ({ eq: jest.fn(() => ({ order: jest.fn(() => Promise.resolve({ data: [], error: null })) })) })) })),
+        };
+    }
+  });
+});
+
+describe("EnhancedProjectDialog", () => {
+  it("loads initial project data when opened", async () => {
+    render(<EnhancedProjectDialog />);
+
+    const trigger = screen.getByRole("button", { name: /projectDialog\.addProject/ });
+    await userEvent.click(trigger);
+
+    await waitFor(() => {
+      expect(mockSupabase.auth.getUser).toHaveBeenCalled();
+    });
+
+    expect(await screen.findByText("Wedding")).toBeInTheDocument();
+    expect(screen.getByText(/placeholders\.select_client_placeholder/)).toBeInTheDocument();
+  });
+
+  it("resets all form state after cancelling and reopening", async () => {
+    render(<EnhancedProjectDialog />);
+
+    const trigger = screen.getByRole("button", { name: /projectDialog\.addProject/ });
+    await userEvent.click(trigger);
+
+    const projectNameInput = await screen.findByLabelText(/projectDialog\.projectName/);
+    await userEvent.clear(projectNameInput);
+    await userEvent.type(projectNameInput, "New Wedding Project");
+
+    const newLeadRadio = screen.getByLabelText(/buttons\.createNewClient/) as HTMLInputElement;
+    await userEvent.click(newLeadRadio);
+    expect(newLeadRadio.checked).toBe(true);
+
+    const newLeadName = screen.getByLabelText(/projectDialog\.name/);
+    await userEvent.type(newLeadName, "Jordan Client");
+
+    const customSetupButton = await screen.findByRole("button", { name: /projectDialog\.setCustomDetails/ });
+    await userEvent.click(customSetupButton);
+
+    const basePriceInput = await screen.findByLabelText(/projectDialog\.basePrice/);
+    await userEvent.clear(basePriceInput);
+    await userEvent.type(basePriceInput, "500");
+
+    const cancelButton = screen.getByRole("button", { name: /buttons\.cancel/ });
+    await userEvent.click(cancelButton);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("enhanced-project-dialog")).not.toBeInTheDocument();
+    });
+
+    await userEvent.click(trigger);
+
+    const resetProjectName = await screen.findByLabelText(/projectDialog\.projectName/);
+    expect((resetProjectName as HTMLInputElement).value).toBe("");
+
+    const newLeadRadioReset = screen.getByLabelText(/buttons\.createNewClient/) as HTMLInputElement;
+    expect(newLeadRadioReset.checked).toBe(false);
+
+    expect(screen.queryByLabelText(/projectDialog\.name/)).not.toBeInTheDocument();
+
+    expect(screen.queryByLabelText(/projectDialog\.basePrice/)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest tests for EnhancedProjectDialog covering initial load and cancel-driven reset behavior
- update the unit testing plan progress snapshot and iteration log for the new coverage

## Testing
- npm test -- EnhancedProjectDialog
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68fc985e85308321a42eca02ed112bcb