### PR TITLE
Add AppSidebar navigation tests

### DIFF
--- a/docs/unit-testing-plan.md
+++ b/docs/unit-testing-plan.md
@@ -39,10 +39,10 @@
 | Core Libraries & Helpers | 13 | 13 | 100% |
 | Services & Data Access | 5 | 5 | 100% |
 | Contexts & Hooks | 24 | 24 | 100% |
-| UI Components & Pages | 13 | 27 | 48% |
+| UI Components & Pages | 14 | 27 | 52% |
 | UI Primitives & Shared Components | 1 | 8 | 13% |
 | Supabase Edge Functions & Automation | 0 | 9 | 0% |
-| **Overall** | **56** | **86** | **65%** |
+| **Overall** | **57** | **86** | **66%** |
 
 ### Core Libraries & Helpers
 | Area | File(s) | What to Cover | Priority | Status | Notes |
@@ -127,7 +127,7 @@
 | Project sheet view | `src/components/ProjectSheetView.tsx` | Printable layout, localization of labels, totals | Medium | Not started | Snapshot layout with English/Turkish translations. |
 | Onboarding modal | `src/components/OnboardingModal.tsx` | Step transitions, skip behavior, analytics events | Medium | Not started | Mock context + ensure stage transitions call hooks. |
 | Dead simple session banner | `src/components/DeadSimpleSessionBanner.tsx` | Feature flag handling, CTA availability, close persistence | Low | Not started | Confirm banner hides once dismissed per user. |
-| App sidebar | `src/components/AppSidebar.tsx` | Active route highlighting, role-based menu items | High | Not started | Mock router + auth roles to confirm navigation gating. |
+| App sidebar | `src/components/AppSidebar.tsx` | Active route highlighting, role-based menu items | High | Done | Covered by `src/components/__tests__/AppSidebar.test.tsx` for active route styling + admin/support visibility. |
 
 ### UI Primitives & Shared Components
 | Area | File(s) | What to Cover | Priority | Status | Notes |
@@ -214,6 +214,7 @@ _Statuses_: `Not started`, `In progress`, `Blocked`, `Ready for review`, `Done`.
 | 2025-10-26 (night) | Codex | Added EnhancedSessionsSection coverage | `src/components/__tests__/EnhancedSessionsSection.test.tsx` verifies lifecycle sorting order, count badge rendering, and banner click wiring | Next: Monitor virtualization thresholds or analytics hooks if they land |
 | 2025-10-26 (late night+) | Codex | Added Enhanced lead edit dialog coverage | `src/components/__tests__/EnhancedEditLeadDialog.test.tsx` exercises prefill, dirty-state detection, validation errors, and Supabase update success toasts | Revisit when dynamic field schema or toast messaging changes |
 | 2025-10-26 (early dawn) | Codex | Added EnhancedProjectDialog coverage | `src/components/__tests__/EnhancedProjectDialog.test.tsx` loads defaults and verifies cancel-driven reset flows | Monitor if project dialog gains new pricing or lead workflows |
+| 2025-10-26 (morning++) | Codex | Added App sidebar navigation coverage | `src/components/__tests__/AppSidebar.test.tsx` ensures active-route highlighting and admin/support menu gating | Revisit onboarding lock behaviour when navigation restrictions change |
 
 ## Maintenance Rules of Thumb
 - Treat this file like the single source of truth for unit testing status—update it in the same PR as any test additions or strategy changes.

--- a/src/components/__tests__/AppSidebar.test.tsx
+++ b/src/components/__tests__/AppSidebar.test.tsx
@@ -1,0 +1,140 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+const sanitizeTestId = (title: string) =>
+  title.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+
+const sidebarNavItemMock = jest.fn(
+  ({ title, children, isActive, isLocked }: any) => (
+    <div
+      data-testid={`nav-${sanitizeTestId(String(title))}`}
+      data-active={isActive ?? false}
+      data-locked={isLocked ?? false}
+    >
+      {title}
+      {children}
+    </div>
+  )
+);
+
+const sidebarSubItemMock = jest.fn(
+  ({ title, isActive, isLocked }: any) => (
+    <div
+      data-testid={`sub-${sanitizeTestId(String(title))}`}
+      data-active={isActive ?? false}
+      data-locked={isLocked ?? false}
+    >
+      {title}
+    </div>
+  )
+);
+
+jest.mock("@/components/ui/sidebar", () => ({
+  Sidebar: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SidebarHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SidebarContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SidebarFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SidebarMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SidebarProvider: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock("@/components/sidebar/SidebarCategory", () => ({
+  SidebarCategory: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock("@/components/sidebar/SidebarNavItem", () => ({
+  SidebarNavItem: (props: any) => sidebarNavItemMock(props),
+}));
+
+jest.mock("@/components/sidebar/SidebarSubItem", () => ({
+  SidebarSubItem: (props: any) => sidebarSubItemMock(props),
+}));
+
+jest.mock("@/components/modals/HelpModal", () => ({
+  HelpModal: () => <div data-testid="help-modal" />, 
+}));
+
+jest.mock("@/components/UserMenu", () => ({
+  UserMenu: () => <div data-testid="user-menu" />, 
+}));
+
+jest.mock("@/components/ui/sheet", () => ({
+  Sheet: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SheetContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SheetHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SheetTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock("@/hooks/useTypedTranslation", () => ({
+  useNavigationTranslation: jest.fn(),
+}));
+
+jest.mock("@/contexts/OnboardingContext", () => ({
+  useOnboarding: jest.fn(),
+}));
+
+jest.mock("@/hooks/useUserRole", () => ({
+  useUserRole: jest.fn(),
+}));
+
+jest.mock("@/hooks/use-mobile", () => ({
+  useIsMobile: jest.fn(),
+}));
+
+jest.mock("@/assets/Logo.png", () => "logo-mock.png", { virtual: true });
+
+import { AppSidebar } from "../AppSidebar";
+import { useNavigationTranslation } from "@/hooks/useTypedTranslation";
+import { useOnboarding } from "@/contexts/OnboardingContext";
+import { useUserRole } from "@/hooks/useUserRole";
+import { useIsMobile } from "@/hooks/use-mobile";
+
+describe("AppSidebar", () => {
+  const renderSidebar = (initialPath: string = "/") =>
+    render(
+      <MemoryRouter initialEntries={[initialPath]}>
+        <AppSidebar />
+      </MemoryRouter>
+    );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (useNavigationTranslation as jest.Mock).mockReturnValue({
+      t: (key: string) => key,
+    });
+
+    (useOnboarding as jest.Mock).mockReturnValue({
+      shouldLockNavigation: false,
+      loading: false,
+    });
+
+    (useIsMobile as jest.Mock).mockReturnValue(false);
+
+    (useUserRole as jest.Mock).mockReturnValue({
+      isAdminOrSupport: jest.fn(() => false),
+    });
+  });
+
+  it("marks the current route as active", () => {
+    renderSidebar("/projects");
+
+    expect(screen.getByTestId("nav-menu-projects")).toHaveAttribute("data-active", "true");
+    expect(screen.getByTestId("nav-menu-dashboard")).toHaveAttribute("data-active", "false");
+  });
+
+  it("renders administration link only for admin or support roles", () => {
+    const initialRender = renderSidebar("/");
+    expect(screen.queryByTestId("nav-menu-administration")).toBeNull();
+
+    initialRender.unmount();
+
+    (useUserRole as jest.Mock).mockReturnValue({
+      isAdminOrSupport: jest.fn(() => true),
+    });
+
+    renderSidebar("/");
+    expect(screen.getByTestId("nav-menu-administration")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add AppSidebar unit tests that verify active route highlighting and admin/support gating
- update the unit testing tracker snapshot, status row, and iteration log for the sidebar coverage

## Testing
- npm run test -- AppSidebar

------
https://chatgpt.com/codex/tasks/task_e_68fc9a8b04408321b6efbfc41cb220e3