### PR TITLE
Add tests for loading skeleton presets

### DIFF
--- a/docs/unit-testing-plan.md
+++ b/docs/unit-testing-plan.md
@@ -40,9 +40,9 @@
 | Services & Data Access | 5 | 5 | 100% |
 | Contexts & Hooks | 24 | 24 | 100% |
 | UI Components & Pages | 14 | 27 | 52% |
-| UI Primitives & Shared Components | 1 | 8 | 13% |
+| UI Primitives & Shared Components | 2 | 8 | 25% |
 | Supabase Edge Functions & Automation | 0 | 9 | 0% |
-| **Overall** | **57** | **86** | **66%** |
+| **Overall** | **58** | **86** | **67%** |
 
 ### Core Libraries & Helpers
 | Area | File(s) | What to Cover | Priority | Status | Notes |
@@ -137,7 +137,7 @@
 | Data table container | `src/components/ui/data-table-container.tsx` | Responsive layout, toolbar slots, sticky headers | Medium | Not started | Snapshot narrow vs wide viewports. |
 | Date/time picker | `src/components/ui/date-time-picker.tsx` | Timezone defaults, validation boundaries | Medium | Not started | Mock date to ensure min/max enforcement. |
 | KPI presets | `src/components/ui/kpi-presets.ts` | Metric formatting, threshold coloring | Low | Done | Covered by `src/components/ui/__tests__/kpi-presets.test.ts` (base classes + overrides). |
-| Loading presets | `src/components/ui/loading-presets.tsx` | Skeleton variants, accessibility roles | Low | Not started | Snapshot skeleton markup for regression protection. |
+| Loading presets | `src/components/ui/loading-presets.tsx` | Skeleton variants, accessibility roles | Low | Done | Covered by `src/components/ui/__tests__/loading-presets.test.tsx` validating wrapper classes and variant props. |
 | Toast hook | `src/components/ui/use-toast.ts` | Queue handling, duplicate suppression, dismissal timers | Medium | Not started | Use fake timers to verify auto-dismiss + manual close. |
 | Toast renderer | `src/components/ui/toaster.tsx` | Mount/unmount behavior, focus management | Medium | Not started | Ensure toasts remain accessible via keyboard navigation. |
 ### Supabase Edge Functions & Automation
@@ -215,6 +215,7 @@ _Statuses_: `Not started`, `In progress`, `Blocked`, `Ready for review`, `Done`.
 | 2025-10-26 (late night+) | Codex | Added Enhanced lead edit dialog coverage | `src/components/__tests__/EnhancedEditLeadDialog.test.tsx` exercises prefill, dirty-state detection, validation errors, and Supabase update success toasts | Revisit when dynamic field schema or toast messaging changes |
 | 2025-10-26 (early dawn) | Codex | Added EnhancedProjectDialog coverage | `src/components/__tests__/EnhancedProjectDialog.test.tsx` loads defaults and verifies cancel-driven reset flows | Monitor if project dialog gains new pricing or lead workflows |
 | 2025-10-26 (morning++) | Codex | Added App sidebar navigation coverage | `src/components/__tests__/AppSidebar.test.tsx` ensures active-route highlighting and admin/support menu gating | Revisit onboarding lock behaviour when navigation restrictions change |
+| 2025-10-26 (afternoon) | Codex | Added loading preset skeleton coverage | `src/components/ui/__tests__/loading-presets.test.tsx` verifies wrapper styling, variant props, and compact/grid fallbacks | Next: Cover toast hook + toaster once queue logic stabilizes |
 
 ## Maintenance Rules of Thumb
 - Treat this file like the single source of truth for unit testing status—update it in the same PR as any test additions or strategy changes.

--- a/src/components/ui/__tests__/loading-presets.test.tsx
+++ b/src/components/ui/__tests__/loading-presets.test.tsx
@@ -1,0 +1,247 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import {
+  PageLoadingSkeleton,
+  DashboardLoadingSkeleton,
+  TableLoadingSkeleton,
+  ListLoadingSkeleton,
+  KanbanLoadingSkeleton,
+  FormLoadingSkeleton,
+  SearchLoadingSkeleton,
+  CompactLoadingSkeleton,
+  CardGridLoadingSkeleton,
+  DetailPageLoadingSkeleton,
+  SettingsLoadingSkeleton,
+} from "../loading-presets";
+
+jest.mock("../loading-skeleton", () => {
+  const React = require("react");
+
+  return {
+    __esModule: true,
+    LoadingSkeleton: ({
+      variant,
+      rows,
+      showHeader,
+      showActions,
+      className,
+    }: any) => {
+      return (
+        <div
+          data-testid="loading-skeleton"
+          data-variant={variant ?? ""}
+          data-rows={rows != null ? String(rows) : ""}
+          data-show-header={showHeader ? "true" : "false"}
+          data-show-actions={showActions ? "true" : "false"}
+          data-class-name={className ?? ""}
+        />
+      );
+    },
+  };
+});
+
+describe("loading-presets", () => {
+  type SkeletonCase = {
+    name: string;
+    Component: React.ComponentType<any>;
+    props?: Record<string, any>;
+    expected: {
+      variant: string;
+      rows?: string;
+      showHeader?: boolean;
+      showActions?: boolean;
+      classForwarded?: boolean;
+    };
+    wrapperClasses?: string[];
+  };
+
+  const skeletonCases: SkeletonCase[] = [
+    {
+      name: "PageLoadingSkeleton",
+      Component: PageLoadingSkeleton,
+      expected: {
+        variant: "settings",
+        rows: "3",
+        showHeader: true,
+        showActions: false,
+        classForwarded: true,
+      },
+    },
+    {
+      name: "DashboardLoadingSkeleton",
+      Component: DashboardLoadingSkeleton,
+      expected: {
+        variant: "dashboard",
+        showHeader: false,
+        showActions: false,
+        classForwarded: false,
+      },
+      wrapperClasses: ["p-4", "sm:p-6"],
+    },
+    {
+      name: "TableLoadingSkeleton",
+      Component: TableLoadingSkeleton,
+      props: { rows: 4 },
+      expected: {
+        variant: "table",
+        rows: "4",
+        showHeader: true,
+        showActions: false,
+        classForwarded: false,
+      },
+      wrapperClasses: ["p-4"],
+    },
+    {
+      name: "ListLoadingSkeleton",
+      Component: ListLoadingSkeleton,
+      props: { rows: 2 },
+      expected: {
+        variant: "list",
+        rows: "2",
+        showHeader: true,
+        showActions: true,
+        classForwarded: false,
+      },
+      wrapperClasses: ["p-4"],
+    },
+    {
+      name: "KanbanLoadingSkeleton",
+      Component: KanbanLoadingSkeleton,
+      expected: {
+        variant: "kanban",
+        showHeader: false,
+        showActions: false,
+        classForwarded: false,
+      },
+      wrapperClasses: ["p-4", "sm:p-6"],
+    },
+    {
+      name: "FormLoadingSkeleton",
+      Component: FormLoadingSkeleton,
+      props: { rows: 7 },
+      expected: {
+        variant: "form",
+        rows: "7",
+        showHeader: true,
+        showActions: true,
+        classForwarded: false,
+      },
+      wrapperClasses: ["p-6"],
+    },
+    {
+      name: "SearchLoadingSkeleton",
+      Component: SearchLoadingSkeleton,
+      props: { rows: 6 },
+      expected: {
+        variant: "search",
+        rows: "6",
+        showHeader: false,
+        showActions: false,
+        classForwarded: false,
+      },
+      wrapperClasses: ["p-4"],
+    },
+    {
+      name: "DetailPageLoadingSkeleton",
+      Component: DetailPageLoadingSkeleton,
+      expected: {
+        variant: "detail-page",
+        showHeader: false,
+        showActions: false,
+        classForwarded: true,
+      },
+    },
+    {
+      name: "SettingsLoadingSkeleton",
+      Component: SettingsLoadingSkeleton,
+      props: { rows: 4 },
+      expected: {
+        variant: "settings",
+        rows: "4",
+        showHeader: true,
+        showActions: true,
+        classForwarded: true,
+      },
+    },
+  ];
+
+  it.each(skeletonCases)(
+    "%s forwards the correct skeleton props",
+    ({ Component, props = {}, expected, wrapperClasses }) => {
+      const { container } = render(<Component className="extra" {...props} />);
+
+      const skeleton = screen.getByTestId("loading-skeleton");
+      expect(skeleton).toHaveAttribute("data-variant", expected.variant);
+
+      if (expected.rows !== undefined) {
+        expect(skeleton).toHaveAttribute("data-rows", expected.rows);
+      } else {
+        expect(skeleton).toHaveAttribute("data-rows", "");
+      }
+
+      if (expected.showHeader !== undefined) {
+        expect(skeleton).toHaveAttribute(
+          "data-show-header",
+          expected.showHeader ? "true" : "false"
+        );
+      }
+
+      if (expected.showActions !== undefined) {
+        expect(skeleton).toHaveAttribute(
+          "data-show-actions",
+          expected.showActions ? "true" : "false"
+        );
+      }
+
+      const forwardedClass = expected.classForwarded ? "extra" : "";
+      expect(skeleton).toHaveAttribute("data-class-name", forwardedClass);
+
+      if (wrapperClasses?.length) {
+        const wrapper = container.firstChild as HTMLElement | null;
+        expect(wrapper).not.toBeNull();
+        wrapperClasses.forEach((className) => {
+          expect(wrapper).toHaveClass(className);
+        });
+        expect(wrapper).toHaveClass("extra");
+      }
+    }
+  );
+
+  it("CompactLoadingSkeleton renders spinner with merged classes", () => {
+    const { container } = render(<CompactLoadingSkeleton className="extra" />);
+
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper).toHaveClass("flex", "items-center", "justify-center", "py-8", "extra");
+    const spinner = wrapper.querySelector(".animate-spin") as HTMLElement | null;
+    expect(spinner).not.toBeNull();
+    expect(spinner).toHaveClass(
+      "h-6",
+      "w-6",
+      "border-2",
+      "border-primary",
+      "border-t-transparent",
+      "rounded-full"
+    );
+  });
+
+  it("CardGridLoadingSkeleton renders the requested number of cards", () => {
+    const { container } = render(
+      <CardGridLoadingSkeleton className="extra" count={4} />
+    );
+
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper).toHaveClass(
+      "grid",
+      "gap-4",
+      "md:grid-cols-2",
+      "lg:grid-cols-3",
+      "p-4",
+      "extra"
+    );
+
+    const cards = container.querySelectorAll(
+      ".animate-pulse.border.rounded-lg"
+    );
+    expect(cards).toHaveLength(4);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit coverage for loading preset components, validating wrapper classes and LoadingSkeleton props
- update the unit testing tracker snapshot, inventory row, and iteration log to reflect the new coverage

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68fc9c7d21ac83219c0ceab244900eaf