### PR TITLE
Add long press button tests

### DIFF
--- a/docs/unit-testing-plan.md
+++ b/docs/unit-testing-plan.md
@@ -40,9 +40,9 @@
 | Services & Data Access | 5 | 5 | 100% |
 | Contexts & Hooks | 24 | 24 | 100% |
 | UI Components & Pages | 14 | 27 | 52% |
-| UI Primitives & Shared Components | 2 | 8 | 25% |
+| UI Primitives & Shared Components | 3 | 8 | 38% |
 | Supabase Edge Functions & Automation | 0 | 9 | 0% |
-| **Overall** | **58** | **86** | **67%** |
+| **Overall** | **59** | **86** | **69%** |
 
 ### Core Libraries & Helpers
 | Area | File(s) | What to Cover | Priority | Status | Notes |
@@ -138,6 +138,7 @@
 | Date/time picker | `src/components/ui/date-time-picker.tsx` | Timezone defaults, validation boundaries | Medium | Not started | Mock date to ensure min/max enforcement. |
 | KPI presets | `src/components/ui/kpi-presets.ts` | Metric formatting, threshold coloring | Low | Done | Covered by `src/components/ui/__tests__/kpi-presets.test.ts` (base classes + overrides). |
 | Loading presets | `src/components/ui/loading-presets.tsx` | Skeleton variants, accessibility roles | Low | Done | Covered by `src/components/ui/__tests__/loading-presets.test.tsx` validating wrapper classes and variant props. |
+| Long press confirmation button | `src/components/ui/long-press-button.tsx` | Hold lifecycle, countdown feedback, completion reset | Medium | Done | Covered by `src/components/ui/__tests__/long-press-button.test.tsx` asserting hold/confirm interactions and post-confirm reset. |
 | Toast hook | `src/components/ui/use-toast.ts` | Queue handling, duplicate suppression, dismissal timers | Medium | Not started | Use fake timers to verify auto-dismiss + manual close. |
 | Toast renderer | `src/components/ui/toaster.tsx` | Mount/unmount behavior, focus management | Medium | Not started | Ensure toasts remain accessible via keyboard navigation. |
 ### Supabase Edge Functions & Automation
@@ -216,6 +217,7 @@ _Statuses_: `Not started`, `In progress`, `Blocked`, `Ready for review`, `Done`.
 | 2025-10-26 (early dawn) | Codex | Added EnhancedProjectDialog coverage | `src/components/__tests__/EnhancedProjectDialog.test.tsx` loads defaults and verifies cancel-driven reset flows | Monitor if project dialog gains new pricing or lead workflows |
 | 2025-10-26 (morning++) | Codex | Added App sidebar navigation coverage | `src/components/__tests__/AppSidebar.test.tsx` ensures active-route highlighting and admin/support menu gating | Revisit onboarding lock behaviour when navigation restrictions change |
 | 2025-10-26 (afternoon) | Codex | Added loading preset skeleton coverage | `src/components/ui/__tests__/loading-presets.test.tsx` verifies wrapper styling, variant props, and compact/grid fallbacks | Next: Cover toast hook + toaster once queue logic stabilizes |
+| 2025-10-26 (evening) | Codex | Added long press confirmation button coverage | `src/components/ui/__tests__/long-press-button.test.tsx` validates hold lifecycle, countdown messaging, and completion reset | Follow up by tackling toast hook/toaster queue scenarios |
 
 ## Maintenance Rules of Thumb
 - Treat this file like the single source of truth for unit testing status—update it in the same PR as any test additions or strategy changes.

--- a/src/components/ui/__tests__/long-press-button.test.tsx
+++ b/src/components/ui/__tests__/long-press-button.test.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { act, fireEvent, render } from "@testing-library/react";
+import { LongPressButton } from "../long-press-button";
+
+describe("LongPressButton", () => {
+  let requestAnimationFrameSpy: jest.SpyInstance<number, [FrameRequestCallback]>;
+  let cancelAnimationFrameSpy: jest.SpyInstance<void, [number]>;
+
+  beforeEach(() => {
+    jest.useFakeTimers({ legacyFakeTimers: true });
+
+    requestAnimationFrameSpy = jest
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation(() => 1);
+
+    cancelAnimationFrameSpy = jest
+      .spyOn(window, "cancelAnimationFrame")
+      .mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    requestAnimationFrameSpy.mockRestore();
+    cancelAnimationFrameSpy.mockRestore();
+    jest.useRealTimers();
+  });
+
+  it("shows holding feedback while pressed and resets on early release", () => {
+    const onConfirm = jest.fn();
+    const { getByRole } = render(
+      <LongPressButton
+        label="Hold to confirm"
+        holdingLabel="Holding"
+        onConfirm={onConfirm}
+        duration={2000}
+      />
+    );
+
+    const button = getByRole("button");
+
+    act(() => {
+      fireEvent.mouseDown(button);
+    });
+
+    expect(button).toHaveTextContent("Holding 2.0s");
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+      fireEvent.mouseUp(button);
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(0);
+    });
+
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(button).toHaveTextContent("Hold to confirm");
+  });
+
+  it("confirms after the hold duration and shows completion state before resetting", () => {
+    const onConfirm = jest.fn();
+    const { getByRole } = render(
+      <LongPressButton
+        label="Hold"
+        completeLabel="Done"
+        holdingLabel="Holding"
+        onConfirm={onConfirm}
+        duration={1000}
+      />
+    );
+
+    const button = getByRole("button");
+
+    act(() => {
+      fireEvent.mouseDown(button);
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(button).toHaveTextContent("Done");
+
+    act(() => {
+      jest.advanceTimersByTime(600);
+    });
+
+    expect(button).toHaveTextContent("Hold");
+  });
+});


### PR DESCRIPTION
## Summary
- add unit coverage for the long press confirmation button component
- update the unit testing tracker with the new UI primitive progress and iteration log entry

## Testing
- npm test -- long-press-button

------
https://chatgpt.com/codex/tasks/task_e_68fc9edbfe88832180d7824f55c2bcfa