### PR TITLE
Add tests for ReminderCard, MobileStickyNav, and TimezoneSelector

### DIFF
--- a/docs/unit-testing-plan.md
+++ b/docs/unit-testing-plan.md
@@ -39,10 +39,10 @@
 | Core Libraries & Helpers | 13 | 13 | 100% |
 | Services & Data Access | 5 | 5 | 100% |
 | Contexts & Hooks | 24 | 24 | 100% |
-| UI Components & Pages | 14 | 27 | 52% |
+| UI Components & Pages | 17 | 27 | 63% |
 | UI Primitives & Shared Components | 3 | 8 | 38% |
 | Supabase Edge Functions & Automation | 0 | 9 | 0% |
-| **Overall** | **59** | **86** | **69%** |
+| **Overall** | **62** | **86** | **72%** |
 
 ### Core Libraries & Helpers
 | Area | File(s) | What to Cover | Priority | Status | Notes |
@@ -218,6 +218,7 @@ _Statuses_: `Not started`, `In progress`, `Blocked`, `Ready for review`, `Done`.
 | 2025-10-26 (morning++) | Codex | Added App sidebar navigation coverage | `src/components/__tests__/AppSidebar.test.tsx` ensures active-route highlighting and admin/support menu gating | Revisit onboarding lock behaviour when navigation restrictions change |
 | 2025-10-26 (afternoon) | Codex | Added loading preset skeleton coverage | `src/components/ui/__tests__/loading-presets.test.tsx` verifies wrapper styling, variant props, and compact/grid fallbacks | Next: Cover toast hook + toaster once queue logic stabilizes |
 | 2025-10-26 (evening) | Codex | Added long press confirmation button coverage | `src/components/ui/__tests__/long-press-button.test.tsx` validates hold lifecycle, countdown messaging, and completion reset | Follow up by tackling toast hook/toaster queue scenarios |
+| 2025-10-26 (late evening) | Codex | Added ReminderCard, MobileStickyNav, and TimezoneSelector coverage | `src/components/__tests__/ReminderCard.test.tsx`, `src/components/__tests__/MobileStickyNav.test.tsx`, `src/components/__tests__/TimezoneSelector.test.tsx` harden reminder badges/toggles, bookings navigation, and timezone auto-detect flows | Keep chipping away at remaining UI component gaps |
 
 ## Maintenance Rules of Thumb
 - Treat this file like the single source of truth for unit testing status—update it in the same PR as any test additions or strategy changes.

--- a/src/components/MobileStickyNav.tsx
+++ b/src/components/MobileStickyNav.tsx
@@ -71,6 +71,7 @@ export function MobileStickyNav() {
             <NavLink
               key={item.title}
               to={item.url}
+              aria-label={item.title}
               className={`h-12 flex items-center justify-center transition-colors ${
                 active
                   ? "bg-primary-foreground/20 text-primary-foreground"
@@ -85,6 +86,7 @@ export function MobileStickyNav() {
         {/* Projects */}
         <NavLink
           to="/projects"
+          aria-label="Projects"
           className={`h-12 flex items-center justify-center transition-colors ${
             isActive("/projects")
               ? "bg-primary-foreground/20 text-primary-foreground"
@@ -98,6 +100,8 @@ export function MobileStickyNav() {
         <div className="relative" ref={menuRef}>
           <button
             onClick={() => setBookingsExpanded(!bookingsExpanded)}
+            aria-label="Bookings menu"
+            aria-expanded={bookingsExpanded}
             className={`h-12 w-full flex items-center justify-center transition-colors ${
               isBookingsActive
                 ? "bg-primary-foreground/20 text-primary-foreground"
@@ -139,6 +143,7 @@ export function MobileStickyNav() {
             <NavLink
               key={item.title}
               to={item.url}
+              aria-label={item.title}
               className={`h-12 flex items-center justify-center transition-colors ${
                 active
                   ? "bg-primary-foreground/20 text-primary-foreground"
@@ -154,6 +159,7 @@ export function MobileStickyNav() {
         <div className="mt-auto">
           <NavLink
             to="/settings"
+            aria-label="Settings"
             className={`h-12 flex items-center justify-center transition-colors ${
               isActive("/settings")
                 ? "bg-primary-foreground/20 text-primary-foreground"

--- a/src/components/ReminderCard.tsx
+++ b/src/components/ReminderCard.tsx
@@ -107,10 +107,14 @@ const ReminderCard = ({
               </div>
               
               {/* Completion toggle - top right, 32px tap area */}
-              <button onClick={e => {
-              e.stopPropagation();
-              onToggleCompletion(activity.id, !activity.completed);
-            }} className="flex items-center justify-center w-8 h-8 rounded-full border-2 border-slate-300 dark:border-slate-600 hover:border-primary hover:bg-primary/5 transition-all duration-200 shrink-0">
+              <button
+                data-testid="toggle-completion"
+                onClick={e => {
+                  e.stopPropagation();
+                  onToggleCompletion(activity.id, !activity.completed);
+                }}
+                className="flex items-center justify-center w-8 h-8 rounded-full border-2 border-slate-300 dark:border-slate-600 hover:border-primary hover:bg-primary/5 transition-all duration-200 shrink-0"
+              >
                 {activity.completed ? <CheckCircle className="h-4 w-4 text-emerald-600 dark:text-emerald-400" /> : <div className="w-2 h-2 rounded-full bg-slate-300 dark:bg-slate-600" />}
               </button>
             </div>
@@ -177,10 +181,14 @@ const ReminderCard = ({
             </div>
 
             {/* Completion Toggle */}
-            <button onClick={e => {
-            e.stopPropagation();
-            onToggleCompletion(activity.id, !activity.completed);
-          }} className="flex items-center justify-center w-6 h-6 rounded-full border-2 border-slate-300 dark:border-slate-600 hover:border-primary hover:bg-primary/5 transition-all duration-200 flex-shrink-0">
+            <button
+              data-testid="toggle-completion"
+              onClick={e => {
+                e.stopPropagation();
+                onToggleCompletion(activity.id, !activity.completed);
+              }}
+              className="flex items-center justify-center w-6 h-6 rounded-full border-2 border-slate-300 dark:border-slate-600 hover:border-primary hover:bg-primary/5 transition-all duration-200 flex-shrink-0"
+            >
               {activity.completed ? <CheckCircle className="h-4 w-4 text-emerald-600 dark:text-emerald-400" /> : <div className="w-2 h-2 rounded-full bg-slate-300 dark:bg-slate-600" />}
             </button>
           </div>

--- a/src/components/__tests__/MobileStickyNav.test.tsx
+++ b/src/components/__tests__/MobileStickyNav.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MobileStickyNav } from "../MobileStickyNav";
+import { MemoryRouter, useLocation } from "react-router-dom";
+
+describe("MobileStickyNav", () => {
+  it("highlights the active navigation item", () => {
+    render(
+      <MemoryRouter initialEntries={["/projects"]}>
+        <MobileStickyNav />
+      </MemoryRouter>
+    );
+
+    const projectsLink = screen.getByRole("link", { name: "Projects" });
+    const dashboardLink = screen.getByRole("link", { name: "Dashboard" });
+
+    expect(projectsLink).toHaveClass("bg-primary-foreground/20");
+    expect(dashboardLink).not.toHaveClass("bg-primary-foreground/20");
+  });
+
+  it("toggles the bookings menu and closes on outside click", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter initialEntries={["/calendar"]}>
+        <MobileStickyNav />
+      </MemoryRouter>
+    );
+
+    const bookingsButton = screen.getByRole("button", { name: "Bookings menu" });
+    expect(bookingsButton).toHaveAttribute("aria-expanded", "false");
+
+    await user.click(bookingsButton);
+    expect(bookingsButton).toHaveAttribute("aria-expanded", "true");
+
+    expect(await screen.findByRole("link", { name: "Sessions" })).toBeInTheDocument();
+
+    fireEvent.mouseDown(document.body);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("link", { name: "Sessions" })).not.toBeInTheDocument();
+    });
+    expect(bookingsButton).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("navigates via bookings menu and collapses after selection", async () => {
+    const user = userEvent.setup();
+    let currentPath = "";
+
+    const LocationObserver = () => {
+      const location = useLocation();
+      currentPath = location.pathname;
+      return null;
+    };
+
+    render(
+      <MemoryRouter initialEntries={["/calendar"]}>
+        <LocationObserver />
+        <MobileStickyNav />
+      </MemoryRouter>
+    );
+
+    const bookingsButton = screen.getByRole("button", { name: "Bookings menu" });
+
+    await user.click(bookingsButton);
+    const remindersLink = await screen.findByRole("link", { name: "Reminders" });
+    await user.click(remindersLink);
+
+    await waitFor(() => {
+      expect(currentPath).toBe("/reminders");
+    });
+
+    expect(screen.queryByRole("link", { name: "Reminders" })).not.toBeInTheDocument();
+    expect(bookingsButton).toHaveAttribute("aria-expanded", "false");
+  });
+});

--- a/src/components/__tests__/ReminderCard.test.tsx
+++ b/src/components/__tests__/ReminderCard.test.tsx
@@ -1,0 +1,96 @@
+import { fireEvent, render, screen } from "@/utils/testUtils";
+import ReminderCard from "../ReminderCard";
+import { useFormsTranslation } from "@/hooks/useTypedTranslation";
+
+jest.mock("@/hooks/useTypedTranslation", () => ({
+  useFormsTranslation: jest.fn(),
+}));
+
+describe("ReminderCard", () => {
+  const mockToggle = jest.fn();
+  const mockClick = jest.fn();
+
+  const baseActivity = {
+    id: "reminder-1",
+    content: "Follow up with client",
+    reminder_date: "2000-05-19",
+    reminder_time: "09:30",
+    type: "reminder",
+    lead_id: "lead-1",
+    created_at: "2024-05-10T00:00:00Z",
+    completed: false,
+  };
+
+  beforeEach(() => {
+    (useFormsTranslation as jest.Mock).mockReturnValue({
+      t: (key: string) => key,
+    });
+    mockToggle.mockReset();
+    mockClick.mockReset();
+  });
+
+  beforeAll(() => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: jest.fn().mockImplementation(() => ({
+        matches: false,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
+  });
+
+  it("shows overdue badge for past reminders and toggles completion", () => {
+    render(
+      <ReminderCard
+        activity={baseActivity}
+        leadName="Jane Doe"
+        onToggleCompletion={mockToggle}
+        onClick={mockClick}
+      />
+    );
+
+    expect(screen.getAllByText("reminders.overdue")[0]).toBeInTheDocument();
+    expect(screen.getAllByText(/reminders\.lead: Jane Doe/)[0]).toBeInTheDocument();
+
+    const toggleButtons = screen.getAllByTestId("toggle-completion");
+    fireEvent.click(toggleButtons[0]);
+
+    expect(mockToggle).toHaveBeenCalledWith("reminder-1", true);
+    expect(mockClick).not.toHaveBeenCalled();
+  });
+
+  it("renders completed state with badge and handles card click", () => {
+    const completedActivity = {
+      ...baseActivity,
+      completed: true,
+      reminder_date: "2100-05-20",
+    };
+
+    render(
+      <ReminderCard
+        activity={completedActivity}
+        leadName="Jane Doe"
+        onToggleCompletion={mockToggle}
+        onClick={mockClick}
+        projectName="Engagement"
+      />
+    );
+
+    expect(screen.getAllByText("reminders.completed")[0]).toBeInTheDocument();
+    expect(screen.queryByText("reminders.overdue")).not.toBeInTheDocument();
+
+    const heading = screen.getAllByText("Follow up with client")[0];
+    expect(heading).toHaveClass("line-through");
+
+    fireEvent.click(heading);
+    expect(mockClick).toHaveBeenCalled();
+
+    const toggleButtons = screen.getAllByTestId("toggle-completion");
+    fireEvent.click(toggleButtons[0]);
+    expect(mockToggle).toHaveBeenCalledWith("reminder-1", false);
+  });
+});

--- a/src/components/__tests__/TimezoneSelector.test.tsx
+++ b/src/components/__tests__/TimezoneSelector.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TimezoneSelector } from "../TimezoneSelector";
+import {
+  detectBrowserTimezone,
+  getSupportedTimezones,
+} from "@/lib/dateFormatUtils";
+
+jest.mock("@/lib/dateFormatUtils", () => ({
+  getSupportedTimezones: jest.fn(),
+  detectBrowserTimezone: jest.fn(),
+}));
+
+describe("TimezoneSelector", () => {
+  const mockOnValueChange = jest.fn();
+  const mockTimezones = [
+    { region: "America", label: "New York (EST)", value: "America/New_York" },
+    { region: "Europe", label: "London (GMT)", value: "Europe/London" },
+    { region: "Asia", label: "Tokyo (JST)", value: "Asia/Tokyo" },
+  ];
+
+  beforeEach(() => {
+    (getSupportedTimezones as jest.Mock).mockReturnValue(mockTimezones);
+    mockOnValueChange.mockReset();
+  });
+
+  beforeAll(() => {
+    Object.defineProperty(HTMLElement.prototype, "hasPointerCapture", {
+      configurable: true,
+      value: jest.fn(),
+    });
+    Object.defineProperty(HTMLElement.prototype, "releasePointerCapture", {
+      configurable: true,
+      value: jest.fn(),
+    });
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: jest.fn(),
+    });
+  });
+
+  it("renders auto-detect shortcut when browser timezone differs", async () => {
+    (detectBrowserTimezone as jest.Mock).mockReturnValue("Europe/London");
+
+    const user = userEvent.setup();
+
+    render(
+      <TimezoneSelector
+        value="America/New_York"
+        onValueChange={mockOnValueChange}
+      />
+    );
+
+    const autoDetectButton = screen.getByRole("button", { name: "Auto-detect" });
+    expect(autoDetectButton).toBeInTheDocument();
+
+    await user.click(autoDetectButton);
+    expect(mockOnValueChange).toHaveBeenCalledWith("Europe/London");
+  });
+
+  it("lists grouped timezone options and propagates selection", async () => {
+    (detectBrowserTimezone as jest.Mock).mockReturnValue("America/New_York");
+
+    const user = userEvent.setup();
+
+    render(
+      <TimezoneSelector value="" onValueChange={mockOnValueChange} />
+    );
+
+    const trigger = screen.getByRole("combobox", { name: "Timezone" });
+    await user.click(trigger);
+
+    const tokyoOption = await screen.findByRole("option", {
+      name: /Tokyo \(JST\)/,
+    });
+
+    expect(tokyoOption).toBeInTheDocument();
+
+    await user.click(tokyoOption);
+    expect(mockOnValueChange).toHaveBeenCalledWith("Asia/Tokyo");
+  });
+
+  it("hides auto-detect button when already using detected timezone", () => {
+    (detectBrowserTimezone as jest.Mock).mockReturnValue("Asia/Tokyo");
+
+    render(
+      <TimezoneSelector value="Asia/Tokyo" onValueChange={mockOnValueChange} />
+    );
+
+    expect(screen.queryByRole("button", { name: "Auto-detect" })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for ReminderCard toggles, badges, and click handling
- verify MobileStickyNav accessibility, menu toggling, and navigation behavior
- exercise TimezoneSelector auto-detect shortcut and grouped option selection while updating the testing progress snapshot

## Testing
- npm test -- --runTestsByPath src/components/__tests__/ReminderCard.test.tsx src/components/__tests__/MobileStickyNav.test.tsx src/components/__tests__/TimezoneSelector.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68fca02f75f8832198414feac41612ba