### PR TITLE
Add unit tests for filter bar and guided mode buttons

### DIFF
--- a/docs/unit-testing-plan.md
+++ b/docs/unit-testing-plan.md
@@ -39,10 +39,10 @@
 | Core Libraries & Helpers | 13 | 13 | 100% |
 | Services & Data Access | 5 | 5 | 100% |
 | Contexts & Hooks | 24 | 24 | 100% |
-| UI Components & Pages | 17 | 27 | 63% |
+| UI Components & Pages | 20 | 30 | 67% |
 | UI Primitives & Shared Components | 3 | 8 | 38% |
 | Supabase Edge Functions & Automation | 0 | 9 | 0% |
-| **Overall** | **62** | **86** | **72%** |
+| **Overall** | **65** | **89** | **73%** |
 
 ### Core Libraries & Helpers
 | Area | File(s) | What to Cover | Priority | Status | Notes |
@@ -127,6 +127,9 @@
 | Project sheet view | `src/components/ProjectSheetView.tsx` | Printable layout, localization of labels, totals | Medium | Not started | Snapshot layout with English/Turkish translations. |
 | Onboarding modal | `src/components/OnboardingModal.tsx` | Step transitions, skip behavior, analytics events | Medium | Not started | Mock context + ensure stage transitions call hooks. |
 | Dead simple session banner | `src/components/DeadSimpleSessionBanner.tsx` | Feature flag handling, CTA availability, close persistence | Low | Not started | Confirm banner hides once dismissed per user. |
+| Reminder filter bar | `src/components/FilterBar.tsx` | Quick filter pills, sheet actions, toggle callbacks | Medium | Done | Covered by `src/components/__tests__/FilterBar.test.tsx` validating pill clicks, sheet clearing, dropdown selection, and toggle handlers. |
+| Restart guided mode button | `src/components/RestartGuidedModeButton.tsx` | Auth gating, onboarding reset, toast and navigation flows | Low | Done | Covered by `src/components/__tests__/RestartGuidedModeButton.test.tsx` ensuring owner guard, success toast, and error handling. |
+| Exit guidance mode button | `src/components/ExitGuidanceModeButton.tsx` | Navigation lock guard, onboarding completion, toast errors | Low | Done | Covered by `src/components/__tests__/ExitGuidanceModeButton.test.tsx` for lock checks, success toast, and failure surfacing. |
 | App sidebar | `src/components/AppSidebar.tsx` | Active route highlighting, role-based menu items | High | Done | Covered by `src/components/__tests__/AppSidebar.test.tsx` for active route styling + admin/support visibility. |
 
 ### UI Primitives & Shared Components
@@ -219,6 +222,7 @@ _Statuses_: `Not started`, `In progress`, `Blocked`, `Ready for review`, `Done`.
 | 2025-10-26 (afternoon) | Codex | Added loading preset skeleton coverage | `src/components/ui/__tests__/loading-presets.test.tsx` verifies wrapper styling, variant props, and compact/grid fallbacks | Next: Cover toast hook + toaster once queue logic stabilizes |
 | 2025-10-26 (evening) | Codex | Added long press confirmation button coverage | `src/components/ui/__tests__/long-press-button.test.tsx` validates hold lifecycle, countdown messaging, and completion reset | Follow up by tackling toast hook/toaster queue scenarios |
 | 2025-10-26 (late evening) | Codex | Added ReminderCard, MobileStickyNav, and TimezoneSelector coverage | `src/components/__tests__/ReminderCard.test.tsx`, `src/components/__tests__/MobileStickyNav.test.tsx`, `src/components/__tests__/TimezoneSelector.test.tsx` harden reminder badges/toggles, bookings navigation, and timezone auto-detect flows | Keep chipping away at remaining UI component gaps |
+| 2025-10-26 (nightfall) | Codex | Added FilterBar + guided mode button coverage | `src/components/__tests__/FilterBar.test.tsx`, `src/components/__tests__/RestartGuidedModeButton.test.tsx`, and `src/components/__tests__/ExitGuidanceModeButton.test.tsx` verify sheet interactions, onboarding resets, navigation locks, and toast flows | Next: Target DeadSimpleSessionBanner and WorkflowHealthDashboard components |
 
 ## Maintenance Rules of Thumb
 - Treat this file like the single source of truth for unit testing status—update it in the same PR as any test additions or strategy changes.

--- a/src/components/__tests__/ExitGuidanceModeButton.test.tsx
+++ b/src/components/__tests__/ExitGuidanceModeButton.test.tsx
@@ -1,0 +1,89 @@
+import userEvent from "@testing-library/user-event";
+import { render, screen, waitFor } from "@/utils/testUtils";
+import { ExitGuidanceModeButton } from "@/components/ExitGuidanceModeButton";
+import { useAuth } from "@/contexts/AuthContext";
+import { useOnboarding } from "@/contexts/OnboardingContext";
+import { useI18nToast } from "@/lib/toastHelpers";
+
+jest.mock("@/contexts/AuthContext", () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock("@/contexts/OnboardingContext", () => ({
+  useOnboarding: jest.fn(),
+}));
+
+jest.mock("@/lib/toastHelpers", () => ({
+  useI18nToast: jest.fn(),
+}));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const mockUseAuth = useAuth as jest.Mock;
+const mockUseOnboarding = useOnboarding as jest.Mock;
+const mockUseI18nToast = useI18nToast as jest.Mock;
+
+describe("ExitGuidanceModeButton", () => {
+  const completeOnboarding = jest.fn();
+  const toastSuccess = jest.fn();
+  const toastError = jest.fn();
+
+  beforeEach(() => {
+    completeOnboarding.mockClear();
+    mockUseI18nToast.mockReturnValue({ success: toastSuccess, error: toastError });
+    completeOnboarding.mockResolvedValue(undefined);
+    toastSuccess.mockClear();
+    toastError.mockClear();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("does not render when user or navigation lock conditions fail", () => {
+    mockUseAuth.mockReturnValue({ user: { email: "someone@example.com" } });
+    mockUseOnboarding.mockReturnValue({ shouldLockNavigation: false, completeOnboarding });
+
+    render(<ExitGuidanceModeButton />);
+    expect(
+      screen.queryByRole("button", { name: "onboarding.buttons.exit_guidance" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("completes onboarding and shows success toast", async () => {
+    const user = userEvent.setup();
+    mockUseAuth.mockReturnValue({ user: { email: "togayaytemiz@gmail.com" } });
+    mockUseOnboarding.mockReturnValue({ shouldLockNavigation: true, completeOnboarding });
+
+    render(<ExitGuidanceModeButton />);
+
+    const button = screen.getByRole("button", { name: "onboarding.buttons.exit_guidance" });
+    await user.click(button);
+
+    expect(completeOnboarding).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalledWith("onboarding.buttons.toast.exit_description"));
+    await waitFor(() => expect(button).not.toBeDisabled());
+  });
+
+  it("surfaces toast errors when completing onboarding fails", async () => {
+    const user = userEvent.setup();
+    const error = new Error("nope");
+    completeOnboarding.mockRejectedValueOnce(error);
+    mockUseAuth.mockReturnValue({ user: { email: "togayaytemiz@gmail.com" } });
+    mockUseOnboarding.mockReturnValue({ shouldLockNavigation: true, completeOnboarding });
+
+    render(<ExitGuidanceModeButton />);
+
+    const button = screen.getByRole("button", { name: "onboarding.buttons.exit_guidance" });
+    await user.click(button);
+
+    expect(completeOnboarding).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith("onboarding.buttons.toast.exit_error"));
+    expect(toastSuccess).not.toHaveBeenCalled();
+    await waitFor(() => expect(button).not.toBeDisabled());
+  });
+});

--- a/src/components/__tests__/FilterBar.test.tsx
+++ b/src/components/__tests__/FilterBar.test.tsx
@@ -1,0 +1,249 @@
+import userEvent from "@testing-library/user-event";
+import { render, screen, within } from "@/utils/testUtils";
+import { FilterBar } from "@/components/FilterBar";
+import { useFormsTranslation } from "@/hooks/useTypedTranslation";
+
+jest.mock("@/components/ui/select", () => {
+  const React = require("react");
+  const SelectContext = React.createContext<{ onValueChange: (value: string) => void }>({
+    onValueChange: () => {},
+  });
+
+  return {
+    __esModule: true,
+    Select: ({ onValueChange, children }: any) => (
+      <SelectContext.Provider value={{ onValueChange }}>{children}</SelectContext.Provider>
+    ),
+    SelectTrigger: ({ children }: any) => <button type="button">{children}</button>,
+    SelectContent: ({ children }: any) => <div>{children}</div>,
+    SelectValue: ({ children }: any) => <span>{children}</span>,
+    SelectItem: ({ value, children }: any) => {
+      const ctx = React.useContext(SelectContext);
+      return (
+        <button type="button" onClick={() => ctx.onValueChange(value)}>
+          {children}
+        </button>
+      );
+    },
+  };
+});
+
+jest.mock("@/components/ui/sheet", () => {
+  const React = require("react");
+  const SheetContext = React.createContext<{ open: boolean; setOpen: (open: boolean) => void }>({
+    open: false,
+    setOpen: () => {},
+  });
+
+  return {
+    __esModule: true,
+    Sheet: ({ open = false, onOpenChange, children }: any) => (
+      <SheetContext.Provider value={{ open, setOpen: (value: boolean) => onOpenChange?.(value) }}>
+        {children}
+      </SheetContext.Provider>
+    ),
+    SheetTrigger: ({ children }: any) => {
+      const ctx = React.useContext(SheetContext);
+      return React.cloneElement(children, {
+        onClick: (...args: any[]) => {
+          children.props?.onClick?.(...args);
+          ctx.setOpen(!ctx.open);
+        },
+      });
+    },
+    SheetContent: ({ children }: any) => {
+      const ctx = React.useContext(SheetContext);
+      return ctx.open ? <div>{children}</div> : null;
+    },
+    SheetHeader: ({ children }: any) => <div>{children}</div>,
+    SheetTitle: ({ children }: any) => <h2>{children}</h2>,
+    SheetFooter: ({ children }: any) => <div>{children}</div>,
+  };
+});
+
+jest.mock("@/hooks/useTypedTranslation", () => ({
+  useFormsTranslation: jest.fn(),
+}));
+
+const formsTranslations: Record<string, string> = {
+  "filterBar.filters": "Filters",
+  "filterBar.clear_all": "Clear all",
+  "filterBar.apply": "Apply",
+  "filterBar.status": "Status",
+  "filterBar.date_range": "Date range",
+  "filterBar.options": "Options",
+  "filterBar.showCompleted": "Show completed",
+  "filterBar.hideOverdue": "Hide overdue",
+};
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) =>
+      formsTranslations[key] ?? options?.defaultValue ?? key,
+  }),
+}));
+
+const mockUseFormsTranslation = useFormsTranslation as jest.Mock;
+
+describe("FilterBar", () => {
+  beforeAll(() => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: jest.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
+  });
+
+  beforeEach(() => {
+    mockUseFormsTranslation.mockReturnValue({
+      t: (key: string, options?: { defaultValue?: string }) =>
+        formsTranslations[key] ?? options?.defaultValue ?? key,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const baseQuickFilters = [
+    { key: "all", label: "All" },
+    { key: "today", label: "Today", count: 2 },
+    { key: "week", label: "This Week", count: 3 },
+  ];
+
+  it("renders quick filters and triggers change handler", async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 'never' });
+    const onQuickFilterChange = jest.fn();
+
+    render(
+      <FilterBar
+        quickFilters={baseQuickFilters}
+        activeQuickFilter="all"
+        onQuickFilterChange={onQuickFilterChange}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /Today/ }));
+
+    expect(onQuickFilterChange).toHaveBeenCalledWith("today");
+  });
+
+  it("shows active filter count when additional filters are applied", () => {
+    const onQuickFilterChange = jest.fn();
+
+    render(
+      <FilterBar
+        quickFilters={baseQuickFilters}
+        activeQuickFilter="all"
+        onQuickFilterChange={onQuickFilterChange}
+        activeStatus="active"
+        activeDateFilter="custom"
+        showCompleted
+        hideOverdue
+      />
+    );
+
+    const filtersButton = screen.getByRole("button", { name: /Filters/ });
+    expect(within(filtersButton).getByText("4")).toBeInTheDocument();
+  });
+
+  it("clears filters from the sheet footer", async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 'never' });
+    const onQuickFilterChange = jest.fn();
+    const onDateFilterChange = jest.fn();
+    const onStatusChange = jest.fn();
+    const onShowCompletedChange = jest.fn();
+    const onHideOverdueChange = jest.fn();
+
+    render(
+      <FilterBar
+        quickFilters={baseQuickFilters}
+        activeQuickFilter="today"
+        onQuickFilterChange={onQuickFilterChange}
+        allDateFilters={[
+          { key: "all", label: "All dates" },
+          { key: "custom", label: "Custom" },
+        ]}
+        activeDateFilter="custom"
+        onDateFilterChange={onDateFilterChange}
+        statusOptions={[
+          { key: "all", label: "All statuses" },
+          { key: "active", label: "Active" },
+        ]}
+        activeStatus="active"
+        onStatusChange={onStatusChange}
+        showCompleted
+        onShowCompletedChange={onShowCompletedChange}
+        hideOverdue
+        onHideOverdueChange={onHideOverdueChange}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /Filters/ }));
+    await user.click(await screen.findByRole("button", { name: /Clear all/ }));
+
+    expect(onQuickFilterChange).toHaveBeenCalledWith("all");
+    expect(onDateFilterChange).toHaveBeenCalledWith("all");
+    expect(onStatusChange).toHaveBeenCalledWith("all");
+    expect(onShowCompletedChange).toHaveBeenCalledWith(false);
+    expect(onHideOverdueChange).not.toHaveBeenCalled();
+  });
+
+  it("invokes status, date, and toggle handlers from the sheet content", async () => {
+    const user = userEvent.setup();
+    const onDateFilterChange = jest.fn();
+    const onStatusChange = jest.fn();
+    const onShowCompletedChange = jest.fn();
+    const onHideOverdueChange = jest.fn();
+
+    render(
+      <FilterBar
+        quickFilters={baseQuickFilters}
+        activeQuickFilter="all"
+        onQuickFilterChange={jest.fn()}
+        allDateFilters={[
+          { key: "all", label: "All dates" },
+          { key: "upcoming", label: "Upcoming" },
+        ]}
+        activeDateFilter="all"
+        onDateFilterChange={onDateFilterChange}
+        statusOptions={[
+          { key: "all", label: "All statuses" },
+          { key: "completed", label: "Completed" },
+        ]}
+        activeStatus="all"
+        onStatusChange={onStatusChange}
+        onShowCompletedChange={onShowCompletedChange}
+        onHideOverdueChange={onHideOverdueChange}
+        showCompleted={false}
+        hideOverdue={false}
+        showCompletedLabel="Show completed"
+        hideOverdueLabel="Hide overdue"
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /Filters/ }));
+
+    // Change date filter
+    await user.click(screen.getByRole("button", { name: /Upcoming/ }));
+    expect(onDateFilterChange).toHaveBeenCalledWith("upcoming");
+
+    // Choose a status option directly from the list
+    await user.click(await screen.findByRole("button", { name: "Completed" }));
+    expect(onStatusChange).toHaveBeenCalledWith("completed");
+
+    await user.click(screen.getByLabelText("Show completed"));
+    expect(onShowCompletedChange).toHaveBeenCalledWith(true);
+
+    await user.click(screen.getByLabelText("Hide overdue"));
+    expect(onHideOverdueChange).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/components/__tests__/RestartGuidedModeButton.test.tsx
+++ b/src/components/__tests__/RestartGuidedModeButton.test.tsx
@@ -1,0 +1,101 @@
+import userEvent from "@testing-library/user-event";
+import { render, screen, waitFor } from "@/utils/testUtils";
+import { RestartGuidedModeButton } from "@/components/RestartGuidedModeButton";
+import { useAuth } from "@/contexts/AuthContext";
+import { useOnboarding } from "@/contexts/OnboardingContext";
+import { useI18nToast } from "@/lib/toastHelpers";
+import { useNavigate } from "react-router-dom";
+
+jest.mock("@/contexts/AuthContext", () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock("@/contexts/OnboardingContext", () => ({
+  useOnboarding: jest.fn(),
+}));
+
+jest.mock("@/lib/toastHelpers", () => ({
+  useI18nToast: jest.fn(),
+}));
+
+const navigateMock = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: jest.fn(() => navigateMock),
+}));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const mockUseAuth = useAuth as jest.Mock;
+const mockUseOnboarding = useOnboarding as jest.Mock;
+const mockUseI18nToast = useI18nToast as jest.Mock;
+const mockUseNavigate = useNavigate as jest.Mock;
+
+describe("RestartGuidedModeButton", () => {
+  const resetOnboarding = jest.fn();
+  const toastSuccess = jest.fn();
+  const toastError = jest.fn();
+
+  beforeEach(() => {
+    resetOnboarding.mockClear();
+    navigateMock.mockClear();
+    mockUseNavigate.mockReturnValue(navigateMock);
+    mockUseI18nToast.mockReturnValue({ success: toastSuccess, error: toastError });
+    resetOnboarding.mockResolvedValue(undefined);
+    toastSuccess.mockClear();
+    toastError.mockClear();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("does not render when user is not the guided mode owner", () => {
+    mockUseAuth.mockReturnValue({ user: { email: "someone@example.com" } });
+    mockUseOnboarding.mockReturnValue({ resetOnboarding });
+
+    render(<RestartGuidedModeButton />);
+    expect(
+      screen.queryByRole("button", { name: "onboarding.buttons.restart_guided_mode" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("restarts guided mode and shows success toast", async () => {
+    const user = userEvent.setup();
+    mockUseAuth.mockReturnValue({ user: { email: "togayaytemiz@gmail.com" } });
+    mockUseOnboarding.mockReturnValue({ resetOnboarding });
+
+    render(<RestartGuidedModeButton />);
+
+    const button = screen.getByRole("button", { name: "onboarding.buttons.restart_guided_mode" });
+    await user.click(button);
+
+    expect(resetOnboarding).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalledWith("onboarding.buttons.toast.restart_description"));
+    expect(navigateMock).toHaveBeenCalledWith("/getting-started");
+    await waitFor(() => expect(button).not.toBeDisabled());
+  });
+
+  it("handles errors when restarting guided mode fails", async () => {
+    const user = userEvent.setup();
+    const error = new Error("boom");
+    resetOnboarding.mockRejectedValueOnce(error);
+    mockUseAuth.mockReturnValue({ user: { email: "togayaytemiz@gmail.com" } });
+    mockUseOnboarding.mockReturnValue({ resetOnboarding });
+
+    render(<RestartGuidedModeButton />);
+
+    const button = screen.getByRole("button", { name: "onboarding.buttons.restart_guided_mode" });
+    await user.click(button);
+
+    expect(resetOnboarding).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith("onboarding.buttons.toast.restart_error"));
+    expect(toastSuccess).not.toHaveBeenCalled();
+    await waitFor(() => expect(button).not.toBeDisabled());
+  });
+});

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -51,3 +51,30 @@ global.IntersectionObserver = jest.fn().mockImplementation(() => ({
   observe: jest.fn(),
   unobserve: jest.fn(),
 }));
+
+// Mock matchMedia for components relying on it (e.g., ThemeProvider)
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});
+
+if (!window.HTMLElement.prototype.hasPointerCapture) {
+  window.HTMLElement.prototype.hasPointerCapture = () => false;
+}
+
+if (!window.HTMLElement.prototype.setPointerCapture) {
+  window.HTMLElement.prototype.setPointerCapture = () => {};
+}
+
+if (!window.HTMLElement.prototype.releasePointerCapture) {
+  window.HTMLElement.prototype.releasePointerCapture = () => {};
+}


### PR DESCRIPTION
## Summary
- add targeted tests for the FilterBar component to exercise quick filters, sheet interactions, and toggle callbacks
- cover the restart and exit guided mode buttons with auth gating, success, and error flows
- extend the shared Jest setup with browser API mocks and refresh the unit testing tracker

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fca2ef9e5083219e8b20d67099b20b