### PR TITLE
Add tests for session banner, workflow health dashboard, and guided progress

### DIFF
--- a/docs/unit-testing-plan.md
+++ b/docs/unit-testing-plan.md
@@ -39,10 +39,10 @@
 | Core Libraries & Helpers | 13 | 13 | 100% |
 | Services & Data Access | 5 | 5 | 100% |
 | Contexts & Hooks | 24 | 24 | 100% |
-| UI Components & Pages | 20 | 30 | 67% |
+| UI Components & Pages | 23 | 30 | 77% |
 | UI Primitives & Shared Components | 3 | 8 | 38% |
 | Supabase Edge Functions & Automation | 0 | 9 | 0% |
-| **Overall** | **65** | **89** | **73%** |
+| **Overall** | **68** | **89** | **76%** |
 
 ### Core Libraries & Helpers
 | Area | File(s) | What to Cover | Priority | Status | Notes |
@@ -107,7 +107,7 @@
 | Session scheduling dialog | `src/components/ScheduleSessionDialog.tsx` | Prefill data, reminder scheduling hooks, status updates | High | Done | Covered via `src/components/__tests__/ScheduleSessionDialog.test.tsx` & `SessionSchedulingSheet.test.tsx`. |
 | Session scheduling sheet | `src/components/SessionSchedulingSheet.tsx` | Mobile sheet state, timezone-aware slots, submission flow | Medium | Not started | Simulate slot selection + validation toasts. |
 | Project Kanban board | `src/components/ProjectKanbanBoard.tsx` | Drag/drop ordering, status filtering, performance memoization | Medium | Not started | Use DnD testing helpers; ensure optimistic UI reverts on error. |
-| Workflow health dashboard | `src/components/WorkflowHealthDashboard.tsx` | Status aggregations, error states, filter interactions | Medium | Not started | Snapshot metrics for empty vs populated data. |
+| Workflow health dashboard | `src/components/WorkflowHealthDashboard.tsx` | Status aggregations, error states, filter interactions | Medium | Done | Covered by `src/components/__tests__/WorkflowHealthDashboard.test.tsx` for loading skeleton, empty state, critical metrics, and action buttons. |
 | Global search | `src/components/GlobalSearch.tsx` | Debounced queries, status preload, keyboard navigation | High | Not started | Mock Supabase search results + user input events. |
 | Protected route guard | `src/components/ProtectedRoute.tsx` | Auth gating, redirect logic, loading fallback | Medium | Done | Covered by `src/components/__tests__/ProtectedRoute.test.tsx` (loading/redirect + onboarding guard). |
 | Route prefetcher | `src/components/RoutePrefetcher.tsx` | Prefetch orchestration, duplicate avoidance | Medium | Done | Covered by `src/components/__tests__/RoutePrefetcher.test.tsx` (cache guard + Supabase prefetch). |
@@ -126,7 +126,8 @@
 | Unified client details | `src/components/UnifiedClientDetails.tsx` | Conditional rendering of contact info, copy buttons | Low | Not started | Verify fallback text when data missing. |
 | Project sheet view | `src/components/ProjectSheetView.tsx` | Printable layout, localization of labels, totals | Medium | Not started | Snapshot layout with English/Turkish translations. |
 | Onboarding modal | `src/components/OnboardingModal.tsx` | Step transitions, skip behavior, analytics events | Medium | Not started | Mock context + ensure stage transitions call hooks. |
-| Dead simple session banner | `src/components/DeadSimpleSessionBanner.tsx` | Feature flag handling, CTA availability, close persistence | Low | Not started | Confirm banner hides once dismissed per user. |
+| Dead simple session banner | `src/components/DeadSimpleSessionBanner.tsx` | Feature flag handling, CTA availability, close persistence | Low | Done | Covered by `src/components/__tests__/DeadSimpleSessionBanner.test.tsx` checking relative badges, project labels, and click handling. |
+| Guided step progress indicator | `src/components/GuidedStepProgress.tsx` | Animation pacing, percentage calculations, copy fallback | Low | Done | Covered by `src/components/__tests__/GuidedStepProgress.test.tsx` verifying animated timer progression and non-animated target display. |
 | Reminder filter bar | `src/components/FilterBar.tsx` | Quick filter pills, sheet actions, toggle callbacks | Medium | Done | Covered by `src/components/__tests__/FilterBar.test.tsx` validating pill clicks, sheet clearing, dropdown selection, and toggle handlers. |
 | Restart guided mode button | `src/components/RestartGuidedModeButton.tsx` | Auth gating, onboarding reset, toast and navigation flows | Low | Done | Covered by `src/components/__tests__/RestartGuidedModeButton.test.tsx` ensuring owner guard, success toast, and error handling. |
 | Exit guidance mode button | `src/components/ExitGuidanceModeButton.tsx` | Navigation lock guard, onboarding completion, toast errors | Low | Done | Covered by `src/components/__tests__/ExitGuidanceModeButton.test.tsx` for lock checks, success toast, and failure surfacing. |
@@ -223,6 +224,7 @@ _Statuses_: `Not started`, `In progress`, `Blocked`, `Ready for review`, `Done`.
 | 2025-10-26 (evening) | Codex | Added long press confirmation button coverage | `src/components/ui/__tests__/long-press-button.test.tsx` validates hold lifecycle, countdown messaging, and completion reset | Follow up by tackling toast hook/toaster queue scenarios |
 | 2025-10-26 (late evening) | Codex | Added ReminderCard, MobileStickyNav, and TimezoneSelector coverage | `src/components/__tests__/ReminderCard.test.tsx`, `src/components/__tests__/MobileStickyNav.test.tsx`, `src/components/__tests__/TimezoneSelector.test.tsx` harden reminder badges/toggles, bookings navigation, and timezone auto-detect flows | Keep chipping away at remaining UI component gaps |
 | 2025-10-26 (nightfall) | Codex | Added FilterBar + guided mode button coverage | `src/components/__tests__/FilterBar.test.tsx`, `src/components/__tests__/RestartGuidedModeButton.test.tsx`, and `src/components/__tests__/ExitGuidanceModeButton.test.tsx` verify sheet interactions, onboarding resets, navigation locks, and toast flows | Next: Target DeadSimpleSessionBanner and WorkflowHealthDashboard components |
+| 2025-10-26 (late night++) | Codex | Added DeadSimpleSessionBanner, WorkflowHealthDashboard, and GuidedStepProgress coverage | `src/components/__tests__/DeadSimpleSessionBanner.test.tsx`, `src/components/__tests__/WorkflowHealthDashboard.test.tsx`, and `src/components/__tests__/GuidedStepProgress.test.tsx` capture relative date badges, health states, and animated progress behavior | Next: Circle back to SessionsSection and SessionSchedulingSheet components |
 
 ## Maintenance Rules of Thumb
 - Treat this file like the single source of truth for unit testing status—update it in the same PR as any test additions or strategy changes.

--- a/src/components/__tests__/DeadSimpleSessionBanner.test.tsx
+++ b/src/components/__tests__/DeadSimpleSessionBanner.test.tsx
@@ -1,0 +1,132 @@
+import { fireEvent, render, screen } from "@/utils/testUtils";
+import DeadSimpleSessionBanner from "../DeadSimpleSessionBanner";
+import { useOrganizationSettings } from "@/hooks/useOrganizationSettings";
+import { getRelativeDate, isOverdueSession } from "@/lib/dateUtils";
+import { getDisplaySessionName } from "@/lib/sessionUtils";
+import { useFormsTranslation, useMessagesTranslation } from "@/hooks/useTypedTranslation";
+
+type Mocked<T> = T extends (...args: infer P) => infer R ? jest.Mock<R, P> : never;
+
+jest.mock("@/hooks/useOrganizationSettings", () => ({
+  useOrganizationSettings: jest.fn(),
+}));
+
+jest.mock("@/lib/dateUtils", () => ({
+  getRelativeDate: jest.fn(),
+  isOverdueSession: jest.fn(),
+}));
+
+jest.mock("@/lib/sessionUtils", () => ({
+  getDisplaySessionName: jest.fn(),
+}));
+
+jest.mock("@/components/SessionStatusBadge", () => ({
+  __esModule: true,
+  SessionStatusBadge: ({ currentStatus }: { currentStatus: string }) => (
+    <div data-testid="session-status-badge">{currentStatus}</div>
+  ),
+  default: ({ currentStatus }: { currentStatus: string }) => (
+    <div data-testid="session-status-badge">{currentStatus}</div>
+  ),
+}));
+
+jest.mock("@/hooks/useTypedTranslation", () => ({
+  useFormsTranslation: jest.fn(),
+  useMessagesTranslation: jest.fn(),
+}));
+
+describe("DeadSimpleSessionBanner", () => {
+  const organizationSettingsMock = useOrganizationSettings as unknown as jest.Mock;
+  const getRelativeDateMock: Mocked<typeof getRelativeDate> = getRelativeDate as any;
+  const isOverdueSessionMock: Mocked<typeof isOverdueSession> = isOverdueSession as any;
+  const getDisplaySessionNameMock: Mocked<typeof getDisplaySessionName> = getDisplaySessionName as any;
+  const useFormsTranslationMock: jest.MockedFunction<typeof useFormsTranslation> = useFormsTranslation as any;
+  const useMessagesTranslationMock: jest.MockedFunction<typeof useMessagesTranslation> = useMessagesTranslation as any;
+
+  const translations = {
+    "relativeDates.today": "Today",
+    "relativeDates.tomorrow": "Tomorrow",
+    "relativeDates.yesterday": "Yesterday",
+    "relativeDates.past_due": "Past due",
+    "sessionLabels.project": "Project",
+  } as const;
+
+  const baseSession = {
+    id: "session-1",
+    session_name: "Strategy Session",
+    session_date: "2024-10-20",
+    session_time: "09:30",
+    status: "planned" as const,
+    lead_id: "lead-1",
+  };
+
+  beforeEach(() => {
+    organizationSettingsMock.mockReturnValue({ settings: { time_format: "12h" } });
+    getDisplaySessionNameMock.mockReturnValue("Strategy Session");
+    const translator = {
+      t: (key: string) => translations[key as keyof typeof translations] ?? key,
+    };
+
+    useFormsTranslationMock.mockReturnValue(translator);
+    useMessagesTranslationMock.mockReturnValue(translator);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows today's indicator and triggers click handler", () => {
+    getRelativeDateMock.mockReturnValue("Today");
+    isOverdueSessionMock.mockReturnValue(false);
+
+    const onClick = jest.fn();
+
+    render(
+      <DeadSimpleSessionBanner
+        session={{ ...baseSession, notes: "Discuss roadmap" }}
+        onClick={onClick}
+      />
+    );
+
+    const todayLabels = screen.getAllByText("Today");
+    expect(todayLabels.length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Strategy Session")).toBeInTheDocument();
+    expect(screen.getByText("Discuss roadmap")).toBeInTheDocument();
+    expect(screen.getByText("09:30 AM")).toBeInTheDocument();
+    expect(screen.getByTestId("session-status-badge").textContent).toBe("planned");
+
+    fireEvent.click(screen.getByText("Strategy Session"));
+
+    expect(onClick).toHaveBeenCalledWith("session-1");
+  });
+
+  it("renders overdue state with project name and badge", () => {
+    getRelativeDateMock.mockReturnValue("Next Week");
+    isOverdueSessionMock.mockReturnValue(true);
+    getDisplaySessionNameMock.mockReturnValue("Planning Call");
+
+    const onClick = jest.fn();
+
+    render(
+      <DeadSimpleSessionBanner
+        session={{
+          ...baseSession,
+          id: "session-2",
+          session_name: "Planning Call",
+          session_date: "2024-10-01",
+          session_time: undefined,
+          status: "no_show",
+          projects: { name: "Q4 Launch" },
+        }}
+        onClick={onClick}
+      />
+    );
+
+    expect(screen.getByText("Past due")).toBeInTheDocument();
+    expect(screen.getByText("Project: Q4 Launch")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Planning Call"));
+
+    expect(onClick).toHaveBeenCalledWith("session-2");
+  });
+});

--- a/src/components/__tests__/GuidedStepProgress.test.tsx
+++ b/src/components/__tests__/GuidedStepProgress.test.tsx
@@ -1,0 +1,70 @@
+import { act, render, screen } from "@/utils/testUtils";
+import { GuidedStepProgress } from "../GuidedStepProgress";
+import { useFormsTranslation } from "@/hooks/useTypedTranslation";
+
+type Mocked<T> = jest.MockedFunction<T>;
+
+jest.mock("@/hooks/useTypedTranslation", () => ({
+  useFormsTranslation: jest.fn(),
+}));
+
+describe("GuidedStepProgress", () => {
+  const useFormsTranslationMock: Mocked<typeof useFormsTranslation> = useFormsTranslation as any;
+  const translations = {
+    "progress.tasks_complete": "tasks complete",
+  } as const;
+
+  beforeEach(() => {
+    useFormsTranslationMock.mockReturnValue({
+      t: (key: string) => translations[key as keyof typeof translations] ?? key,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.useRealTimers();
+  });
+
+  it("renders the target value immediately when animation is disabled", () => {
+    render(
+      <GuidedStepProgress
+        currentValue={2}
+        targetValue={8}
+        totalSteps={10}
+        animate={false}
+      />
+    );
+
+    const fraction = screen.getByText((content, element) =>
+      element?.classList.contains("tabular-nums") && content.replace(/\s+/g, "") === "8/10"
+    );
+    expect(fraction).toBeInTheDocument();
+
+    const indicator = screen.getByRole("progressbar").querySelector('[style*="translateX"]');
+    expect(indicator).toHaveStyle({ transform: "translateX(-20%)" });
+  });
+
+  it("animates towards the target value when enabled", () => {
+    jest.useFakeTimers({ doNotFake: ["performance"] });
+
+    render(
+      <GuidedStepProgress
+        currentValue={1}
+        targetValue={6}
+        totalSteps={10}
+      />
+    );
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    const fraction = screen.getByText((content, element) =>
+      element?.classList.contains("tabular-nums") && content.replace(/\s+/g, "") === "6/10"
+    );
+    expect(fraction).toBeInTheDocument();
+
+    const indicator = screen.getByRole("progressbar").querySelector('[style*="translateX"]');
+    expect(indicator).toHaveStyle({ transform: "translateX(-40%)" });
+  });
+});

--- a/src/components/__tests__/WorkflowHealthDashboard.test.tsx
+++ b/src/components/__tests__/WorkflowHealthDashboard.test.tsx
@@ -1,0 +1,136 @@
+import { fireEvent, render, screen } from "@/utils/testUtils";
+import { WorkflowHealthDashboard } from "../WorkflowHealthDashboard";
+import { useWorkflowHealth } from "@/hooks/useWorkflowHealth";
+
+jest.mock("@/hooks/useWorkflowHealth", () => ({
+  useWorkflowHealth: jest.fn(),
+}));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, any>, defaultValue?: string) => {
+      const translations: Record<string, string> = {
+        "workflows.health.unableToLoad": "Unable to load",
+        "workflows.health.status.title": "Workflow health",
+        "workflows.health.status.description": "Monitor your automations",
+        "workflows.health.status.labels.healthy": "Healthy",
+        "workflows.health.status.labels.warning": "Warning",
+        "workflows.health.status.labels.critical": "Critical",
+        "workflows.health.critical.title": "Critical issues detected",
+        "workflows.health.warning.title": "Needs attention",
+        "workflows.health.actions.cleanup": "Clean up stuck runs",
+        "workflows.health.actions.refresh": "Refresh",
+        "workflows.health.actions.systemTitle": "System actions",
+        "workflows.health.actions.systemDescription": "Keep workflows humming",
+        "workflows.health.metrics.totalWorkflows": "Total workflows",
+        "workflows.health.metrics.successRate": "Success rate",
+        "workflows.health.metrics.recentExecutions": "Recent executions",
+        "workflows.health.metrics.averageExecutionTime": "Avg execution time",
+        "workflows.health.metrics.dailyTitle": "Daily performance",
+        "workflows.health.metrics.dailyDescription": "Per-day stats",
+        "workflows.health.metrics.successRateSubtitle": "Success over last 7 days",
+        "workflows.health.metrics.recentExecutionsSubtitle": "Runs in the last 24h",
+        "workflows.health.metrics.averageExecutionTimeSubtitle": "Average time per workflow",
+      };
+
+      switch (key) {
+        case "workflows.health.metrics.totalSubtitle":
+          return `Active ${options?.active} · Paused ${options?.paused}`;
+        case "workflows.health.metrics.dailyTotal":
+          return `Total ${options?.count}`;
+        case "workflows.health.metrics.dailySuccess":
+          return `Success ${options?.rate}%`;
+        case "workflows.health.metrics.dailyAverage":
+          return `Avg ${options?.time}`;
+        case "workflows.health.critical.stuckExecutions":
+          return `Stuck ${options?.count}`;
+        case "workflows.health.critical.lowSuccessRate":
+          return `Low success ${options?.rate}%`;
+        case "common:abbreviations.notAvailable":
+          return defaultValue ?? "N/A";
+        default:
+          return translations[key] ?? key;
+      }
+    },
+  }),
+}));
+
+describe("WorkflowHealthDashboard", () => {
+  const useWorkflowHealthMock = useWorkflowHealth as jest.Mock;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders loading skeleton while data is fetching", () => {
+    useWorkflowHealthMock.mockReturnValue({
+      loading: true,
+      health: null,
+    });
+
+    const { container } = render(<WorkflowHealthDashboard />);
+
+    expect(container.querySelectorAll(".animate-pulse")).toHaveLength(4);
+  });
+
+  it("shows empty state when health is unavailable", () => {
+    useWorkflowHealthMock.mockReturnValue({
+      loading: false,
+      health: null,
+    });
+
+    render(<WorkflowHealthDashboard />);
+
+    expect(screen.getByText("Unable to load")).toBeInTheDocument();
+  });
+
+  it("displays critical health details and triggers actions", () => {
+    const cleanupStuckExecutions = jest.fn();
+    const refetch = jest.fn();
+
+    useWorkflowHealthMock.mockReturnValue({
+      loading: false,
+      health: {
+        totalWorkflows: 12,
+        activeWorkflows: 6,
+        pausedWorkflows: 6,
+        successRate: 72.3,
+        recentExecutions: 45,
+        averageExecutionTime: 185,
+        stuckExecutions: 3,
+        metrics: [
+          {
+            id: "metric-1",
+            date: "2024-10-24T00:00:00Z",
+            total_executions: 20,
+            successful_executions: 14,
+            average_execution_time_ms: 210,
+          },
+        ],
+      },
+      cleanupStuckExecutions,
+      getHealthIcon: () => <span data-testid="health-icon">!</span>,
+      getHealthStatus: () => "critical",
+      refetch,
+    });
+
+    render(<WorkflowHealthDashboard />);
+
+    expect(screen.getByText("Critical")).toBeInTheDocument();
+    expect(screen.getByText("Stuck 3")).toBeInTheDocument();
+    expect(screen.getByText("Low success 72.3%"))
+      .toBeInTheDocument();
+    expect(screen.getByText("Active 6 · Paused 6")).toBeInTheDocument();
+    expect(screen.getByText("Success 70.0%"))
+      .toBeInTheDocument();
+    expect(screen.getByText("Avg 210"))
+      .toBeInTheDocument();
+
+    const cleanupButtons = screen.getAllByText("Clean up stuck runs");
+    cleanupButtons.forEach((button) => fireEvent.click(button));
+    fireEvent.click(screen.getByText("Refresh"));
+
+    expect(cleanupStuckExecutions).toHaveBeenCalledTimes(2);
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add DeadSimpleSessionBanner tests covering relative date badges, project details, and click handling
- cover GuidedStepProgress animation and non-animated behavior with deterministic timer control
- exercise WorkflowHealthDashboard loading, empty, and critical states while updating the unit testing tracker snapshot

## Testing
- npm test -- --runTestsByPath src/components/__tests__/DeadSimpleSessionBanner.test.tsx src/components/__tests__/GuidedStepProgress.test.tsx src/components/__tests__/WorkflowHealthDashboard.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68fca66cad008321a09c08013d2b4927