### PR TITLE
Add coverage for UnifiedClientDetails and toast hook

### DIFF
--- a/docs/unit-testing-plan.md
+++ b/docs/unit-testing-plan.md
@@ -39,10 +39,10 @@
 | Core Libraries & Helpers | 13 | 13 | 100% |
 | Services & Data Access | 5 | 5 | 100% |
 | Contexts & Hooks | 24 | 24 | 100% |
-| UI Components & Pages | 23 | 30 | 77% |
-| UI Primitives & Shared Components | 3 | 8 | 38% |
+| UI Components & Pages | 26 | 30 | 87% |
+| UI Primitives & Shared Components | 4 | 8 | 50% |
 | Supabase Edge Functions & Automation | 0 | 9 | 0% |
-| **Overall** | **68** | **89** | **76%** |
+| **Overall** | **71** | **89** | **80%** |
 
 ### Core Libraries & Helpers
 | Area | File(s) | What to Cover | Priority | Status | Notes |
@@ -105,7 +105,7 @@
 | Enhanced lead edit | `src/components/EnhancedEditLeadDialog.tsx` | Prefill logic, change detection, update mutation flow | High | Done | Covered by `src/components/__tests__/EnhancedEditLeadDialog.test.tsx` for prefill, validation, and Supabase updates. |
 | Enhanced project dialog | `src/components/EnhancedProjectDialog.tsx` | Cross-entity linking, lead selection, Supabase upserts | High | Done | Covered by `src/components/__tests__/EnhancedProjectDialog.test.tsx` ensuring data fetch, custom setup, and close/reopen resets. |
 | Session scheduling dialog | `src/components/ScheduleSessionDialog.tsx` | Prefill data, reminder scheduling hooks, status updates | High | Done | Covered via `src/components/__tests__/ScheduleSessionDialog.test.tsx` & `SessionSchedulingSheet.test.tsx`. |
-| Session scheduling sheet | `src/components/SessionSchedulingSheet.tsx` | Mobile sheet state, timezone-aware slots, submission flow | Medium | Not started | Simulate slot selection + validation toasts. |
+| Session scheduling sheet | `src/components/SessionSchedulingSheet.tsx` | Mobile sheet state, timezone-aware slots, submission flow | Medium | Done | Covered by `src/components/__tests__/SessionSchedulingSheet.test.tsx` validating slot selection, summary updates, and guarded closing. |
 | Project Kanban board | `src/components/ProjectKanbanBoard.tsx` | Drag/drop ordering, status filtering, performance memoization | Medium | Not started | Use DnD testing helpers; ensure optimistic UI reverts on error. |
 | Workflow health dashboard | `src/components/WorkflowHealthDashboard.tsx` | Status aggregations, error states, filter interactions | Medium | Done | Covered by `src/components/__tests__/WorkflowHealthDashboard.test.tsx` for loading skeleton, empty state, critical metrics, and action buttons. |
 | Global search | `src/components/GlobalSearch.tsx` | Debounced queries, status preload, keyboard navigation | High | Not started | Mock Supabase search results + user input events. |
@@ -121,9 +121,9 @@
 | Session form fields | `src/components/SessionFormFields.tsx` | Validation messaging, timezone-aware inputs, reminders toggles | Medium | Done | Covered by `src/components/__tests__/SessionFormFields.test.tsx` (project selector + field callbacks). |
 | Session status badge | `src/components/SessionStatusBadge.tsx` | Lifecycle color mapping, accessible labels | Low | Done | Covered by `src/components/__tests__/SessionStatusBadge.test.tsx` (loading badge + editable dropdown updates). |
 | Project payments section | `src/components/ProjectPaymentsSection.tsx` | Summary cards, refresh triggers, empty states | Medium | Done | Covered by `src/components/__tests__/ProjectPaymentsSection.test.tsx` for metrics, refresh callback, and empty state. |
-| Sessions section surface | `src/components/SessionsSection.tsx` | Tab filtering, sorting integration, quick actions | Medium | Not started | Stub hooks to return sample data + assert CTA availability. |
+| Sessions section surface | `src/components/SessionsSection.tsx` | Tab filtering, sorting integration, quick actions | Medium | Done | Covered by `src/components/__tests__/SessionsSection.test.tsx` for skeleton state, empty CTA wiring, and banner/sheet interactions. |
 | Enhanced sessions section | `src/components/EnhancedSessionsSection.tsx` | Multi-column layout, performance instrumentation | Medium | Done | Covered by `src/components/__tests__/EnhancedSessionsSection.test.tsx` verifying lifecycle sorting, count badge, and click wiring. |
-| Unified client details | `src/components/UnifiedClientDetails.tsx` | Conditional rendering of contact info, copy buttons | Low | Not started | Verify fallback text when data missing. |
+| Unified client details | `src/components/UnifiedClientDetails.tsx` | Conditional rendering of contact info, copy buttons | Low | Done | Covered by `src/components/__tests__/UnifiedClientDetails.test.tsx` validating quick actions, custom field display, navigation hooks, and validation toasts. |
 | Project sheet view | `src/components/ProjectSheetView.tsx` | Printable layout, localization of labels, totals | Medium | Not started | Snapshot layout with English/Turkish translations. |
 | Onboarding modal | `src/components/OnboardingModal.tsx` | Step transitions, skip behavior, analytics events | Medium | Not started | Mock context + ensure stage transitions call hooks. |
 | Dead simple session banner | `src/components/DeadSimpleSessionBanner.tsx` | Feature flag handling, CTA availability, close persistence | Low | Done | Covered by `src/components/__tests__/DeadSimpleSessionBanner.test.tsx` checking relative badges, project labels, and click handling. |
@@ -143,7 +143,7 @@
 | KPI presets | `src/components/ui/kpi-presets.ts` | Metric formatting, threshold coloring | Low | Done | Covered by `src/components/ui/__tests__/kpi-presets.test.ts` (base classes + overrides). |
 | Loading presets | `src/components/ui/loading-presets.tsx` | Skeleton variants, accessibility roles | Low | Done | Covered by `src/components/ui/__tests__/loading-presets.test.tsx` validating wrapper classes and variant props. |
 | Long press confirmation button | `src/components/ui/long-press-button.tsx` | Hold lifecycle, countdown feedback, completion reset | Medium | Done | Covered by `src/components/ui/__tests__/long-press-button.test.tsx` asserting hold/confirm interactions and post-confirm reset. |
-| Toast hook | `src/components/ui/use-toast.ts` | Queue handling, duplicate suppression, dismissal timers | Medium | Not started | Use fake timers to verify auto-dismiss + manual close. |
+| Toast hook | `src/components/ui/use-toast.ts` | Queue handling, duplicate suppression, dismissal timers | Medium | Done | Covered by `src/components/ui/__tests__/use-toast.test.ts` using fake timers for queue limits, updates, and dismiss removal. |
 | Toast renderer | `src/components/ui/toaster.tsx` | Mount/unmount behavior, focus management | Medium | Not started | Ensure toasts remain accessible via keyboard navigation. |
 ### Supabase Edge Functions & Automation
 | Area | File(s) | What to Cover | Priority | Status | Notes |
@@ -225,6 +225,7 @@ _Statuses_: `Not started`, `In progress`, `Blocked`, `Ready for review`, `Done`.
 | 2025-10-26 (late evening) | Codex | Added ReminderCard, MobileStickyNav, and TimezoneSelector coverage | `src/components/__tests__/ReminderCard.test.tsx`, `src/components/__tests__/MobileStickyNav.test.tsx`, `src/components/__tests__/TimezoneSelector.test.tsx` harden reminder badges/toggles, bookings navigation, and timezone auto-detect flows | Keep chipping away at remaining UI component gaps |
 | 2025-10-26 (nightfall) | Codex | Added FilterBar + guided mode button coverage | `src/components/__tests__/FilterBar.test.tsx`, `src/components/__tests__/RestartGuidedModeButton.test.tsx`, and `src/components/__tests__/ExitGuidanceModeButton.test.tsx` verify sheet interactions, onboarding resets, navigation locks, and toast flows | Next: Target DeadSimpleSessionBanner and WorkflowHealthDashboard components |
 | 2025-10-26 (late night++) | Codex | Added DeadSimpleSessionBanner, WorkflowHealthDashboard, and GuidedStepProgress coverage | `src/components/__tests__/DeadSimpleSessionBanner.test.tsx`, `src/components/__tests__/WorkflowHealthDashboard.test.tsx`, and `src/components/__tests__/GuidedStepProgress.test.tsx` capture relative date badges, health states, and animated progress behavior | Next: Circle back to SessionsSection and SessionSchedulingSheet components |
+| 2025-10-27 | Codex | Hardened UnifiedClientDetails and toast hook coverage | Added `src/components/__tests__/UnifiedClientDetails.test.tsx` and `src/components/ui/__tests__/use-toast.test.ts` while reconciling sheet/section status rows | Next: Target `GlobalSearch` debounced query flows |
 
 ## Maintenance Rules of Thumb
 - Treat this file like the single source of truth for unit testing status—update it in the same PR as any test additions or strategy changes.

--- a/src/components/__tests__/UnifiedClientDetails.test.tsx
+++ b/src/components/__tests__/UnifiedClientDetails.test.tsx
@@ -1,0 +1,266 @@
+import type { ReactElement, ReactNode } from "react";
+import { act, fireEvent, render, screen } from "@/utils/testUtils";
+import { UnifiedClientDetails } from "../UnifiedClientDetails";
+
+const toastMock = jest.fn();
+const updateCoreFieldMock = jest.fn();
+const updateCustomFieldMock = jest.fn();
+const refetchFieldValuesMock = jest.fn();
+
+jest.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+const useLeadFieldDefinitionsMock = jest.fn();
+jest.mock("@/hooks/useLeadFieldDefinitions", () => ({
+  useLeadFieldDefinitions: () => useLeadFieldDefinitionsMock(),
+}));
+
+const useLeadFieldValuesMock = jest.fn();
+jest.mock("@/hooks/useLeadFieldValues", () => ({
+  useLeadFieldValues: () => useLeadFieldValuesMock(),
+}));
+
+jest.mock("@/hooks/useLeadUpdate", () => ({
+  useLeadUpdate: () => ({
+    updateCoreField: updateCoreFieldMock,
+    updateCustomField: updateCustomFieldMock,
+  }),
+}));
+
+jest.mock("@/components/fields/CustomFieldDisplay", () => ({
+  CustomFieldDisplay: ({ value }: { value: string | null }) => (
+    <span data-testid="custom-display">{value ?? "empty"}</span>
+  ),
+}));
+
+jest.mock("@/components/fields/CustomFieldDisplayWithEmpty", () => ({
+  CustomFieldDisplayWithEmpty: ({
+    fieldDefinition,
+    value,
+  }: {
+    fieldDefinition: { field_key: string };
+    value: string | null;
+  }) => (
+    <span
+      data-field-key={fieldDefinition.field_key}
+      data-testid={`custom-${fieldDefinition.field_key}`}
+    >
+      {value ?? "empty"}
+    </span>
+  ),
+}));
+
+jest.mock("@/components/fields/FieldTextareaDisplay", () => ({
+  FieldTextareaDisplay: ({ value }: { value: string }) => (
+    <span data-testid="textarea-display">{value}</span>
+  ),
+}));
+
+jest.mock("@/components/fields/InlineEditField", () => {
+  const saveHandlers = new Map<string, (value: string) => void>();
+  return {
+    __esModule: true,
+    InlineEditField: ({
+      children,
+      onSave,
+    }: {
+      children: ReactNode;
+      onSave: (value: string) => void;
+    }) => {
+      const child = (Array.isArray(children)
+        ? (children[0] as ReactElement | undefined)
+        : (children as ReactElement | undefined)) ?? null;
+      const fieldKey =
+        (child?.props && (child.props["data-field-key"] as string)) ||
+        (child?.props && (child.props["data-testid"] as string)) ||
+        `field-${saveHandlers.size}`;
+
+      const saveValue = child?.props?.["data-field-key"]
+        ? " invalid value "
+        : "Updated Value";
+
+      saveHandlers.set(fieldKey, onSave);
+
+      return (
+        <div data-testid={`inline-${fieldKey}`} data-inline-key={fieldKey}>
+          {children}
+          <button
+            type="button"
+            data-testid={`save-${fieldKey}`}
+            onClick={() => onSave(saveValue)}
+          >
+            trigger-save
+          </button>
+        </div>
+      );
+    },
+    saveHandlers,
+  };
+});
+
+jest.mock("@/components/fields/inline-editors/InlineTextEditor", () => ({
+  InlineTextEditor: () => <div data-testid="inline-text-editor" />,
+}));
+
+jest.mock("@/components/fields/inline-editors/InlineTextareaEditor", () => ({
+  InlineTextareaEditor: () => <div data-testid="inline-textarea-editor" />,
+}));
+
+jest.mock("@/components/fields/inline-editors/InlineEmailEditor", () => ({
+  InlineEmailEditor: () => <div data-testid="inline-email-editor" />,
+}));
+
+jest.mock("@/components/fields/inline-editors/InlinePhoneEditor", () => ({
+  InlinePhoneEditor: () => <div data-testid="inline-phone-editor" />,
+}));
+
+jest.mock("@/components/fields/inline-editors/InlineSelectEditor", () => ({
+  InlineSelectEditor: () => <div data-testid="inline-select-editor" />,
+}));
+
+jest.mock("@/components/fields/inline-editors/InlineMultiSelectEditor", () => ({
+  InlineMultiSelectEditor: () => (
+    <div data-testid="inline-multiselect-editor" />
+  ),
+}));
+
+jest.mock("@/components/fields/inline-editors/InlineNumberEditor", () => ({
+  InlineNumberEditor: () => <div data-testid="inline-number-editor" />,
+}));
+
+jest.mock("@/components/fields/inline-editors/InlineDateEditor", () => ({
+  InlineDateEditor: () => <div data-testid="inline-date-editor" />,
+}));
+
+jest.mock("@/components/fields/inline-editors/InlineCheckboxEditor", () => ({
+  InlineCheckboxEditor: () => <div data-testid="inline-checkbox-editor" />,
+}));
+
+jest.mock("../EnhancedEditLeadDialog", () => ({
+  EnhancedEditLeadDialog: () => <div data-testid="enhanced-edit-lead-dialog" />,
+}));
+
+const validateFieldValueMock = jest.fn();
+jest.mock("@/lib/leadFieldValidation", () => ({
+  validateFieldValue: (value: string | null) => validateFieldValueMock(value),
+}));
+
+jest.mock("@/hooks/useTypedTranslation", () => ({
+  useFormsTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe("UnifiedClientDetails", () => {
+  const baseLead = {
+    id: "lead-1",
+    name: "Test Lead",
+    email: "lead@example.com",
+    phone: "0555 123 4567",
+    notes: null,
+  };
+
+  beforeEach(() => {
+    toastMock.mockReset();
+    updateCoreFieldMock.mockReset();
+    updateCustomFieldMock.mockReset();
+    refetchFieldValuesMock.mockReset();
+    validateFieldValueMock.mockReturnValue({ isValid: true });
+
+    useLeadFieldDefinitionsMock.mockReturnValue({
+      fieldDefinitions: [
+        {
+          field_key: "instagram",
+          label: "Instagram",
+          field_type: "text",
+          allow_multiple: false,
+          sort_order: 1,
+          options: { options: [] },
+          validation_rules: {},
+        },
+      ],
+      loading: false,
+    });
+
+    useLeadFieldValuesMock.mockReturnValue({
+      fieldValues: [
+        {
+          field_key: "instagram",
+          value: "@test",
+        },
+      ],
+      loading: false,
+      refetch: refetchFieldValuesMock,
+    });
+  });
+
+  it("renders lead details with quick actions and custom fields", () => {
+    const navigateToLead = jest.fn();
+
+    render(
+      <UnifiedClientDetails
+        lead={baseLead}
+        title="Client"
+        showQuickActions
+        showClickableNames
+        onNavigateToLead={navigateToLead}
+        createdAt="2024-01-05T00:00:00.000Z"
+      />
+    );
+
+    expect(screen.getByText("Client")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Test Lead" }));
+    expect(navigateToLead).toHaveBeenCalledWith("lead-1");
+
+    expect(
+      screen.getByRole("link", { name: "clientDetails.whatsApp" })
+    ).toHaveAttribute("href", "https://wa.me/905551234567");
+    expect(
+      screen.getByRole("link", { name: "clientDetails.call" })
+    ).toHaveAttribute("href", "tel:+905551234567");
+    expect(
+      screen.getByRole("link", { name: "clientDetails.email" })
+    ).toHaveAttribute("href", "mailto:lead@example.com");
+
+    expect(screen.getByTestId("custom-instagram")).toHaveTextContent("@test");
+    expect(
+      screen.getByText(/clientDetails.createdOn/)
+    ).toBeInTheDocument();
+  });
+
+  it("shows validation toast and avoids saving invalid custom field values", async () => {
+    validateFieldValueMock.mockReturnValue({
+      isValid: false,
+      error: "Invalid field value",
+    });
+
+    render(
+      <UnifiedClientDetails
+        lead={baseLead}
+        showQuickActions={false}
+      />
+    );
+
+    const inlineContainer = screen.getByTestId("custom-instagram").parentElement as HTMLElement;
+    const inlineKey = inlineContainer.dataset.inlineKey ?? "";
+    const { saveHandlers } = jest.requireMock("@/components/fields/InlineEditField") as {
+      saveHandlers: Map<string, (value: string) => Promise<void> | void>;
+    };
+    const customSave = saveHandlers.get(inlineKey);
+    expect(customSave).toBeDefined();
+
+    await act(async () => {
+      await customSave!(" invalid value ");
+    });
+
+    expect(validateFieldValueMock).toHaveBeenCalledWith("invalid value");
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variant: "destructive",
+        description: "Invalid field value",
+      })
+    );
+    expect(updateCustomFieldMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/ui/__tests__/use-toast.test.ts
+++ b/src/components/ui/__tests__/use-toast.test.ts
@@ -1,0 +1,82 @@
+import { act, renderHook } from "@testing-library/react";
+import { toast, useToast } from "@/hooks/use-toast";
+
+const clearToasts = () => {
+  const { result, unmount } = renderHook(() => useToast());
+  act(() => {
+    result.current.dismiss();
+    jest.runOnlyPendingTimers();
+  });
+  unmount();
+};
+
+beforeEach(() => {
+  jest.useFakeTimers({ doNotFake: ["performance"] });
+  clearToasts();
+});
+
+afterEach(() => {
+  clearToasts();
+  jest.useRealTimers();
+});
+
+describe("toast hook", () => {
+  it("adds toasts and enforces the queue limit", () => {
+    const { result, unmount } = renderHook(() => useToast());
+
+    act(() => {
+      toast({ title: "First" });
+    });
+
+    expect(result.current.toasts).toHaveLength(1);
+    expect(result.current.toasts[0].title).toBe("First");
+
+    act(() => {
+      toast({ title: "Second" });
+    });
+
+    expect(result.current.toasts).toHaveLength(1);
+    expect(result.current.toasts[0].title).toBe("Second");
+
+    unmount();
+  });
+
+  it("dismisses toasts and removes them after the timer elapses", () => {
+    const { result, unmount } = renderHook(() => useToast());
+
+    let toastId = "";
+    act(() => {
+      toastId = toast({ title: "Dismiss me" }).id;
+    });
+
+    act(() => {
+      result.current.dismiss(toastId);
+    });
+
+    expect(result.current.toasts[0].open).toBe(false);
+
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(result.current.toasts).toHaveLength(0);
+
+    unmount();
+  });
+
+  it("allows updating toast properties", () => {
+    const { result, unmount } = renderHook(() => useToast());
+
+    act(() => {
+      const handle = toast({ title: "Initial", description: "Original" });
+      handle.update({ description: "Updated" } as any);
+    });
+
+    expect(result.current.toasts[0]).toMatchObject({
+      title: "Initial",
+      description: "Updated",
+    });
+
+    unmount();
+  });
+});


### PR DESCRIPTION
## Summary
- add targeted unit tests for UnifiedClientDetails covering quick actions, custom-field validation, and navigation wiring
- exercise the toast hook queue, dismissal, and update flows with dedicated jest tests and timer hygiene
- refresh the unit-testing plan progress snapshot, status rows, and iteration log to reflect the new coverage

## Testing
- npm run test -- --runTestsByPath src/components/__tests__/UnifiedClientDetails.test.tsx src/components/ui/__tests__/use-toast.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68fca913503083219212a0bc50b9cfae