### PR TITLE
Add tests for progress, switch, and toast primitives

### DIFF
--- a/docs/unit-testing-plan.md
+++ b/docs/unit-testing-plan.md
@@ -40,9 +40,9 @@
 | Services & Data Access | 5 | 5 | 100% |
 | Contexts & Hooks | 24 | 24 | 100% |
 | UI Components & Pages | 30 | 30 | 100% |
-| UI Primitives & Shared Components | 9 | 13 | 69% |
+| UI Primitives & Shared Components | 13 | 13 | 100% |
 | Supabase Edge Functions & Automation | 0 | 9 | 0% |
-| **Overall** | **81** | **94** | **86%** |
+| **Overall** | **85** | **94** | **90%** |
 
 ### Core Libraries & Helpers
 | Area | File(s) | What to Cover | Priority | Status | Notes |
@@ -151,6 +151,10 @@
 | Page header layout | `src/components/ui/page-header.tsx` | Sticky wrapper, responsive slots, action grouping | Low | Done | Covered by `src/components/ui/__tests__/page-header.test.tsx` confirming sticky classes and slot layout wrappers. |
 | Pagination primitives | `src/components/ui/pagination.tsx` | i18n labels, aria-current handling, ellipsis semantics | Low | Done | Covered by `src/components/ui/__tests__/pagination.test.tsx` checking navigation labeling, active link, and ellipsis sr-only text. |
 | Card primitives | `src/components/ui/card.tsx` | Section wrappers, class forwarding, text slots | Low | Done | Covered by `src/components/ui/__tests__/card.test.tsx` asserting class merging and content rendering across sections. |
+| Progress display bar | `src/components/ui/progress-bar.tsx` | Completion labeling, success state styling, size variants | Low | Done | Covered by `src/components/ui/__tests__/progress-bar.test.tsx` validating label toggles, success coloring, and width calculations. |
+| Progress primitive wrapper | `src/components/ui/progress.tsx` | Value-to-transform mapping, default fallback state | Low | Done | Covered by `src/components/ui/__tests__/progress.test.tsx` ensuring default translate and value-driven offsets. |
+| Switch toggle | `src/components/ui/switch.tsx` | Data-state transitions, controlled toggles, accessibility attributes | Low | Done | Covered by `src/components/ui/__tests__/switch.test.tsx` asserting unchecked/checked transitions and controlled updates. |
+| Toast primitives | `src/components/ui/toast.tsx` | Viewport mounting, variant styling, close/action wiring | Medium | Done | Covered by `src/components/ui/__tests__/toast.test.tsx` confirming viewport class merge, destructive styling, and close attributes. |
 ### Supabase Edge Functions & Automation
 | Area | File(s) | What to Cover | Priority | Status | Notes |
 | --- | --- | --- | --- | --- | --- |
@@ -233,6 +237,7 @@ _Statuses_: `Not started`, `In progress`, `Blocked`, `Ready for review`, `Done`.
 | 2025-10-26 (late night++) | Codex | Added DeadSimpleSessionBanner, WorkflowHealthDashboard, and GuidedStepProgress coverage | `src/components/__tests__/DeadSimpleSessionBanner.test.tsx`, `src/components/__tests__/WorkflowHealthDashboard.test.tsx`, and `src/components/__tests__/GuidedStepProgress.test.tsx` capture relative date badges, health states, and animated progress behavior | Next: Circle back to SessionsSection and SessionSchedulingSheet components |
 | 2025-10-27 | Codex | Hardened UnifiedClientDetails and toast hook coverage | Added `src/components/__tests__/UnifiedClientDetails.test.tsx` and `src/components/ui/__tests__/use-toast.test.ts` while reconciling sheet/section status rows | Next: Target `GlobalSearch` debounced query flows |
 | 2025-10-28 | Codex | Added Session banner, User menu, and UI primitive coverage | Added tests for `src/components/SessionBanner.tsx`, `src/components/UserMenu.tsx`, and new UI primitives (`segmented-control`, `page-header`, `pagination`, `card`) to lock in action handling and accessibility | Next: Focus on GlobalSearch keyboard interactions and Supabase function harnesses |
+| 2025-10-28 (later still) | Codex | Completed remaining UI primitive gaps | Added `src/components/ui/__tests__/progress-bar.test.tsx`, `progress.test.tsx`, `switch.test.tsx`, and `toast.test.tsx` to cover progress transforms, toggle data-state transitions, and toast viewport/variant styling | Next: Begin data-table primitive harness and toast renderer coverage |
 
 ## Maintenance Rules of Thumb
 - Treat this file like the single source of truth for unit testing status—update it in the same PR as any test additions or strategy changes.

--- a/src/components/ui/__tests__/progress-bar.test.tsx
+++ b/src/components/ui/__tests__/progress-bar.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@/utils/testUtils";
+import { ProgressBar } from "../progress-bar";
+
+describe("ProgressBar", () => {
+  it("renders the completion label when requested", () => {
+    const { container } = render(
+      <ProgressBar value={40} total={5} completed={2} showLabel />
+    );
+
+    expect(screen.getByText("2/5")).toBeInTheDocument();
+
+    const indicator = container.querySelector(
+      '[style*="width: 40%"]'
+    ) as HTMLElement | null;
+    expect(indicator).toBeInTheDocument();
+    expect(indicator).toHaveStyle({ width: "40%" });
+  });
+
+  it("applies the success color once complete and adjusts height for size", () => {
+    const { container } = render(
+      <ProgressBar
+        value={100}
+        total={3}
+        completed={3}
+        size="md"
+        showLabel
+      />
+    );
+
+    const track = container.querySelector(".h-3");
+    expect(track).toBeInTheDocument();
+
+    const indicator = container.querySelector(".bg-green-600") as HTMLElement | null;
+    expect(indicator).toBeInTheDocument();
+    expect(indicator).toHaveStyle({ width: "100%" });
+  });
+
+  it("hides the label when total is zero or showLabel is false", () => {
+    const { rerender } = render(
+      <ProgressBar value={10} total={0} completed={0} showLabel />
+    );
+
+    expect(screen.queryByText("0/0")).not.toBeInTheDocument();
+
+    rerender(
+      <ProgressBar value={10} total={4} completed={1} showLabel={false} />
+    );
+
+    expect(screen.queryByText("1/4")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/ui/__tests__/progress.test.tsx
+++ b/src/components/ui/__tests__/progress.test.tsx
@@ -1,0 +1,22 @@
+import { render } from "@/utils/testUtils";
+import { Progress } from "../progress";
+
+describe("Progress", () => {
+  it("renders with a default transform when no value is provided", () => {
+    const { container } = render(<Progress />);
+    const indicator = container.querySelector(
+      '[style*="translateX"]'
+    ) as HTMLElement | null;
+    expect(indicator).toBeInTheDocument();
+    expect(indicator).toHaveStyle({ transform: "translateX(-100%)" });
+  });
+
+  it("reflects the provided value as a translate offset", () => {
+    const { container } = render(<Progress value={65} />);
+    const indicator = container.querySelector(
+      '[style*="translateX"]'
+    ) as HTMLElement | null;
+    expect(indicator).toBeInTheDocument();
+    expect(indicator).toHaveStyle({ transform: "translateX(-35%)" });
+  });
+});

--- a/src/components/ui/__tests__/switch.test.tsx
+++ b/src/components/ui/__tests__/switch.test.tsx
@@ -1,0 +1,26 @@
+import userEvent from "@testing-library/user-event";
+import { render, screen } from "@/utils/testUtils";
+import { Switch } from "../switch";
+
+describe("Switch", () => {
+  it("reflects its checked state through data attributes", async () => {
+    const user = userEvent.setup();
+    render(<Switch />);
+
+    const toggle = screen.getByRole("switch");
+    expect(toggle).toHaveAttribute("data-state", "unchecked");
+
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute("data-state", "checked");
+  });
+
+  it("supports controlled checked state", () => {
+    const { rerender } = render(<Switch checked={false} onCheckedChange={() => {}} />);
+
+    const toggle = screen.getByRole("switch");
+    expect(toggle).toHaveAttribute("data-state", "unchecked");
+
+    rerender(<Switch checked onCheckedChange={() => {}} />);
+    expect(toggle).toHaveAttribute("data-state", "checked");
+  });
+});

--- a/src/components/ui/__tests__/toast.test.tsx
+++ b/src/components/ui/__tests__/toast.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@/utils/testUtils";
+import {
+  Toast,
+  ToastAction,
+  ToastClose,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+} from "../toast";
+
+describe("Toast primitives", () => {
+  it("renders the viewport with provided class names", async () => {
+    render(
+      <ToastProvider>
+        <ToastViewport className="custom-viewport" />
+      </ToastProvider>
+    );
+
+    const region = await screen.findByRole("region", {
+      name: /notifications/i,
+    });
+    const viewport = region.querySelector("ol") as HTMLElement | null;
+    expect(viewport).toBeInTheDocument();
+    expect(viewport).toHaveClass("custom-viewport");
+  });
+
+  it("applies variant styling and exposes close/action primitives", () => {
+    const { rerender } = render(
+      <ToastProvider>
+        <Toast open data-testid="toast" onOpenChange={() => {}}>
+          <ToastTitle>Heads up</ToastTitle>
+          <ToastDescription>All good!</ToastDescription>
+          <ToastAction altText="Undo">Undo</ToastAction>
+          <ToastClose data-testid="close" />
+        </Toast>
+        <ToastViewport />
+      </ToastProvider>
+    );
+
+    const toast = screen.getByTestId("toast");
+    expect(toast.className).toContain("border bg-background");
+
+    const closeButton = screen.getByTestId("close");
+    expect(closeButton).toHaveAttribute("toast-close", "");
+
+    rerender(
+      <ToastProvider>
+        <Toast
+          open
+          data-testid="toast"
+          onOpenChange={() => {}}
+          variant="destructive"
+        >
+          <ToastTitle>Warning</ToastTitle>
+          <ToastDescription>Problem!</ToastDescription>
+          <ToastAction altText="Dismiss">Dismiss</ToastAction>
+          <ToastClose data-testid="close" />
+        </Toast>
+        <ToastViewport />
+      </ToastProvider>
+    );
+
+    const destructiveToast = screen.getByTestId("toast");
+    expect(destructiveToast.className).toContain("destructive");
+  });
+});


### PR DESCRIPTION
## Summary
- add targeted tests covering the progress bar, progress primitive, switch toggle, and toast primitives
- update the unit testing plan snapshot and iteration log to reflect the new UI primitive coverage

## Testing
- npm test -- --runTestsByPath src/components/ui/__tests__/progress-bar.test.tsx src/components/ui/__tests__/progress.test.tsx src/components/ui/__tests__/switch.test.tsx src/components/ui/__tests__/toast.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68fcb7d6373083219e79ba9a2328ff5b