### PR TITLE
Add tests for session reminder processor function

### DIFF
--- a/docs/unit-testing-plan.md
+++ b/docs/unit-testing-plan.md
@@ -41,8 +41,8 @@
 | Contexts & Hooks | 24 | 24 | 100% |
 | UI Components & Pages | 30 | 30 | 100% |
 | UI Primitives & Shared Components | 13 | 13 | 100% |
-| Supabase Edge Functions & Automation | 2 | 9 | 22% |
-| **Overall** | **87** | **94** | **93%** |
+| Supabase Edge Functions & Automation | 3 | 9 | 33% |
+| **Overall** | **88** | **94** | **94%** |
 
 ### Core Libraries & Helpers
 | Area | File(s) | What to Cover | Priority | Status | Notes |
@@ -240,6 +240,7 @@ _Statuses_: `Not started`, `In progress`, `Blocked`, `Ready for review`, `Done`.
 | 2025-10-28 | Codex | Added Session banner, User menu, and UI primitive coverage | Added tests for `src/components/SessionBanner.tsx`, `src/components/UserMenu.tsx`, and new UI primitives (`segmented-control`, `page-header`, `pagination`, `card`) to lock in action handling and accessibility | Next: Focus on GlobalSearch keyboard interactions and Supabase function harnesses |
 | 2025-10-28 (later still) | Codex | Completed remaining UI primitive gaps | Added `src/components/ui/__tests__/progress-bar.test.tsx`, `progress.test.tsx`, `switch.test.tsx`, and `toast.test.tsx` to cover progress transforms, toggle data-state transitions, and toast viewport/variant styling | Next: Begin data-table primitive harness and toast renderer coverage |
 | 2025-10-29 | Codex | Added Supabase automation coverage | Added Deno tests for `get-users-email`, `schedule-daily-notifications`, and shared email localization helpers to verify validation, scheduling, and i18n fallbacks | Continue expanding coverage across remaining notification + workflow functions |
+| 2025-10-29 (later) | Codex | Added session reminder processor coverage | Added Deno tests for `process-session-reminders` covering fetch failures, invalid session data guards, workflow trigger errors, and cleanup RPC execution | Next: target `send-reminder-notifications` and `workflow-executor` orchestration paths |
 
 ## Maintenance Rules of Thumb
 - Treat this file like the single source of truth for unit testing status—update it in the same PR as any test additions or strategy changes.

--- a/supabase/functions/process-session-reminders/index.ts
+++ b/supabase/functions/process-session-reminders/index.ts
@@ -1,12 +1,12 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.3";
 
-const corsHeaders = {
+export const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
 
-const handler = async (req: Request): Promise<Response> => {
+export const handler = async (req: Request): Promise<Response> => {
   console.log('Session reminders processor started');
 
   if (req.method === 'OPTIONS') {
@@ -43,7 +43,7 @@ const handler = async (req: Request): Promise<Response> => {
   }
 };
 
-async function processScheduledReminders(supabase: any) {
+export async function processScheduledReminders(supabase: any) {
   console.log('Processing scheduled session reminders');
 
   // Get reminders that are due to be sent (exact timing, no early processing buffer)

--- a/supabase/functions/tests/process-session-reminders.test.ts
+++ b/supabase/functions/tests/process-session-reminders.test.ts
@@ -1,0 +1,205 @@
+import { assertEquals, assertRejects } from "https://deno.land/std@0.224.0/testing/asserts.ts";
+import { processScheduledReminders } from "../process-session-reminders/index.ts";
+
+type Reminder = {
+  id: string;
+  session_id: string;
+  reminder_type: string;
+  scheduled_for: string;
+  organization_id: string;
+  workflow_id: string | null;
+  sessions: any;
+  workflows?: any;
+};
+
+type StubOptions = {
+  dueReminders?: Reminder[];
+  fetchError?: Error;
+  triggerError?: string;
+  cleanupError?: Error;
+  cleanupResult?: number;
+  updateResponses?: Array<{ error: { message: string } | null }>;
+};
+
+type UpdateCall = {
+  table: string;
+  values: Record<string, unknown>;
+  filters: Array<{ field: string; value: unknown }>;
+};
+
+type SelectCall = {
+  table: string;
+  filters: Array<{ type: "eq" | "lte"; field: string; value: unknown }>;
+  orderBy?: string;
+};
+
+function createSupabaseStub(options: StubOptions = {}) {
+  const selectCalls: SelectCall[] = [];
+  const updateCalls: UpdateCall[] = [];
+  const invokeCalls: Array<{ name: string; payload: unknown }> = [];
+  const rpcCalls: string[] = [];
+  const updateResponses = [...(options.updateResponses ?? [])];
+
+  class SelectQuery {
+    private filters: Array<{ type: "eq" | "lte"; field: string; value: unknown }> = [];
+    constructor(private readonly table: string) {}
+
+    eq(field: string, value: unknown) {
+      this.filters.push({ type: "eq", field, value });
+      return this;
+    }
+
+    lte(field: string, value: unknown) {
+      this.filters.push({ type: "lte", field, value });
+      return this;
+    }
+
+    order(field: string) {
+      selectCalls.push({
+        table: this.table,
+        filters: [...this.filters],
+        orderBy: field,
+      });
+
+      if (options.fetchError) {
+        return Promise.resolve({ data: null, error: options.fetchError });
+      }
+
+      return Promise.resolve({ data: options.dueReminders ?? [], error: null });
+    }
+  }
+
+  class UpdateQuery {
+    private readonly filters: Array<{ field: string; value: unknown }> = [];
+    constructor(private readonly table: string, private readonly values: Record<string, unknown>) {}
+
+    eq(field: string, value: unknown) {
+      this.filters.push({ field, value });
+      return this;
+    }
+
+    then<TResult1 = unknown, TResult2 = never>(
+      onfulfilled?: ((value: { error: { message: string } | null }) => TResult1 | PromiseLike<TResult1>) | undefined,
+      onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | undefined,
+    ) {
+      updateCalls.push({ table: this.table, values: this.values, filters: [...this.filters] });
+      const response = updateResponses.length > 0 ? updateResponses.shift()! : { error: null };
+      return Promise.resolve(response).then(onfulfilled, onrejected);
+    }
+  }
+
+  return {
+    selectCalls,
+    updateCalls,
+    invokeCalls,
+    rpcCalls,
+    from(table: string) {
+      if (table === "scheduled_session_reminders") {
+        return {
+          select: () => new SelectQuery(table),
+          update: (values: Record<string, unknown>) => new UpdateQuery(table, values),
+        };
+      }
+      throw new Error(`Unexpected table: ${table}`);
+    },
+    functions: {
+      invoke: async (name: string, payload: unknown) => {
+        invokeCalls.push({ name, payload });
+        if (options.triggerError) {
+          return { error: { message: options.triggerError } };
+        }
+        return { error: null };
+      },
+    },
+    rpc: async (name: string) => {
+      rpcCalls.push(name);
+      if (options.cleanupError) {
+        return { data: null, error: options.cleanupError };
+      }
+      return { data: options.cleanupResult ?? 0, error: null };
+    },
+  };
+}
+
+function buildReminder(overrides: Partial<Reminder> = {}): Reminder {
+  return {
+    id: overrides.id ?? crypto.randomUUID(),
+    session_id: overrides.session_id ?? "session-123",
+    reminder_type: overrides.reminder_type ?? "email",
+    scheduled_for: overrides.scheduled_for ?? new Date().toISOString(),
+    organization_id: overrides.organization_id ?? "org-1",
+    workflow_id: overrides.workflow_id ?? "workflow-1",
+    sessions: overrides.sessions ?? {
+      id: "session-123",
+      session_date: "2025-01-01",
+      session_time: "10:00",
+      location: "Studio",
+      notes: "Bring props",
+      leads: {
+        id: "lead-1",
+        name: "Jane Doe",
+        email: "jane@example.com",
+        phone: "+15555550123",
+      },
+    },
+    workflows: overrides.workflows ?? null,
+  };
+}
+
+Deno.test("throws when fetching due reminders fails", async () => {
+  const fetchError = new Error("unable to load reminders");
+  const supabase = createSupabaseStub({ fetchError });
+
+  await assertRejects(() => processScheduledReminders(supabase as unknown as any), Error, "unable to load reminders");
+  assertEquals(supabase.invokeCalls.length, 0);
+});
+
+Deno.test("returns zero counts when no reminders are due", async () => {
+  const supabase = createSupabaseStub({ dueReminders: [] });
+
+  const result = await processScheduledReminders(supabase as unknown as any);
+
+  assertEquals(result, { processed: 0, triggered: 0, failed: 0 });
+  assertEquals(supabase.invokeCalls.length, 0);
+  assertEquals(supabase.updateCalls.length, 0);
+});
+
+Deno.test("marks reminders with missing session data as failed", async () => {
+  const reminder = buildReminder({ sessions: null as unknown as Reminder["sessions"] });
+  const supabase = createSupabaseStub({ dueReminders: [reminder] });
+
+  const result = await processScheduledReminders(supabase as unknown as any);
+
+  assertEquals(result, { processed: 1, triggered: 0, failed: 1 });
+  assertEquals(supabase.updateCalls.length, 1);
+  assertEquals(supabase.updateCalls[0].values.status, "failed");
+});
+
+Deno.test("records failures when workflow trigger errors occur", async () => {
+  const reminder = buildReminder();
+  const supabase = createSupabaseStub({ dueReminders: [reminder], triggerError: "workflow failed" });
+
+  const result = await processScheduledReminders(supabase as unknown as any);
+
+  assertEquals(result, { processed: 1, triggered: 0, failed: 1 });
+  assertEquals(supabase.invokeCalls.length, 1);
+  assertEquals(supabase.invokeCalls[0].name, "workflow-executor");
+  assertEquals(supabase.updateCalls.length, 2);
+  assertEquals(supabase.updateCalls[0].values.status, "sent");
+  assertEquals(supabase.updateCalls[1].values.status, "failed");
+});
+
+Deno.test("successfully triggers workflows for valid reminders", async () => {
+  const reminder = buildReminder();
+  const supabase = createSupabaseStub({ dueReminders: [reminder], cleanupResult: 2 });
+
+  const result = await processScheduledReminders(supabase as unknown as any);
+
+  assertEquals(result, { processed: 1, triggered: 1, failed: 0 });
+  assertEquals(supabase.invokeCalls.length, 1);
+  const payload = supabase.invokeCalls[0].payload as { body: Record<string, unknown> };
+  assertEquals(payload.body.action, "trigger");
+  assertEquals(payload.body.trigger_type, "session_reminder");
+  assertEquals(payload.body.trigger_data?.reminder_type, reminder.reminder_type);
+  assertEquals(supabase.rpcCalls, ["cleanup_old_session_reminders"]);
+});


### PR DESCRIPTION
## Summary
- export the process-session-reminders internals so they can be exercised directly in Deno tests
- add a focused test suite that verifies fetch failures, invalid data guards, workflow trigger errors, and successful reminder processing paths
- update the unit testing tracker to log the new Supabase function coverage and refreshed progress snapshot

## Testing
- npm run test:deno *(fails: deno: not found in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68fcbbdd07e8832190620e6d7a4ead15