### PR TITLE
Add Supabase workflow executor and template email test coverage

### DIFF
--- a/docs/unit-testing-plan.md
+++ b/docs/unit-testing-plan.md
@@ -41,8 +41,8 @@
 | Contexts & Hooks | 24 | 24 | 100% |
 | UI Components & Pages | 30 | 30 | 100% |
 | UI Primitives & Shared Components | 13 | 13 | 100% |
-| Supabase Edge Functions & Automation | 4 | 9 | 44% |
-| **Overall** | **89** | **94** | **95%** |
+| Supabase Edge Functions & Automation | 6 | 9 | 67% |
+| **Overall** | **91** | **94** | **97%** |
 
 ### Core Libraries & Helpers
 | Area | File(s) | What to Cover | Priority | Status | Notes |
@@ -158,13 +158,13 @@
 ### Supabase Edge Functions & Automation
 | Area | File(s) | What to Cover | Priority | Status | Notes |
 | --- | --- | --- | --- | --- | --- |
-| Workflow executor | `supabase/functions/workflow-executor/index.ts` | Trigger filtering, duplicate prevention, action switch | High | Not started | Use Deno test harness; stub Supabase admin client responses. |
+| Workflow executor | `supabase/functions/workflow-executor/index.ts` | Trigger filtering, duplicate prevention, action switch | High | Done | Covered by `supabase/functions/tests/workflow-executor.test.ts` for action dispatch, reminder scheduling, and duplicate guards. |
 | Session reminder processor | `supabase/functions/process-session-reminders/index.ts` | Due reminder selection, workflow invocation, failure handling | High | Not started | Simulate mixed reminder payloads, ensure status updates idempotent. |
 | Reminder notifications sender | `supabase/functions/send-reminder-notifications/index.ts` | Email templating branches, batch mode, auth flows | High | Done | Covered via `supabase/functions/tests/send-reminder-notifications.test.ts` for assignment + milestone paths with mocked Resend/Supabase. |
 | Notification queue processor | `supabase/functions/notification-processor/index.ts` | Queue polling, retry logic, failure escalation | Medium | Not started | Validate exponential backoff + dead-letter handling. |
 | Daily scheduling cron | `supabase/functions/schedule-daily-notifications/index.ts` | Window calculations, dedupe of scheduled jobs | Medium | Done | Covered by `supabase/functions/tests/schedule-daily-notifications.test.ts` with fixed clock + insert/dedupe paths. |
 | Simplified daily scheduler | `supabase/functions/simple-daily-notifications/index.ts` | Lightweight cron fallback, idempotent inserts | Low | Not started | Ensure it exits early when main scheduler already ran. |
-| Template email sender | `supabase/functions/send-template-email/index.ts` | Template lookup, localization, Resend payload | High | Not started | Stub template data + ensure placeholders resolve. |
+| Template email sender | `supabase/functions/send-template-email/index.ts` | Template lookup, localization, Resend payload | High | Done | Validated via `supabase/functions/tests/send-template-email.test.ts` for placeholder fallbacks and block ordering. |
 | User email lookup | `supabase/functions/get-users-email/index.ts` | Auth enforcement, filtering, pagination | Medium | Done | Covered by `supabase/functions/tests/get-users-email.test.ts` for happy path, validation, and failure skips. |
 | Email localization helpers | `supabase/functions/_shared/email-i18n.ts` | Language normalization, fallback to EN, list helpers | Low | Done | Validated via `supabase/functions/tests/email-i18n.test.ts` for default, Turkish, and fallback behaviors. |
 | Test callback harness | `supabase/functions/test-callback/index.ts` | Echo behavior, validation of payload schema | Low | Not started | Keep as sanity check for function invocation plumbing. |
@@ -242,6 +242,7 @@ _Statuses_: `Not started`, `In progress`, `Blocked`, `Ready for review`, `Done`.
 | 2025-10-29 | Codex | Added Supabase automation coverage | Added Deno tests for `get-users-email`, `schedule-daily-notifications`, and shared email localization helpers to verify validation, scheduling, and i18n fallbacks | Continue expanding coverage across remaining notification + workflow functions |
 | 2025-10-29 (later) | Codex | Added session reminder processor coverage | Added Deno tests for `process-session-reminders` covering fetch failures, invalid session data guards, workflow trigger errors, and cleanup RPC execution | Next: target `send-reminder-notifications` and `workflow-executor` orchestration paths |
 | 2025-10-29 (night) | Codex | Added reminder notification coverage | Added `supabase/functions/tests/send-reminder-notifications.test.ts` to cover assignment opt-out/success and milestone fan-out flows with injected Resend client | Next: Expand `workflow-executor` orchestration tests |
+| 2025-10-30 | Codex | Added workflow executor + template email coverage | `supabase/functions/tests/workflow-executor.test.ts` validates trigger filtering, duplicate prevention, and action dispatch; `supabase/functions/tests/send-template-email.test.ts` locks placeholder fallbacks and block ordering | Next: Cover notification processor queue handling and simple daily scheduler paths |
 
 ## Maintenance Rules of Thumb
 - Treat this file like the single source of truth for unit testing status—update it in the same PR as any test additions or strategy changes.

--- a/supabase/functions/send-template-email/index.ts
+++ b/supabase/functions/send-template-email/index.ts
@@ -34,7 +34,7 @@ interface SendEmailRequest {
   workflow_execution_id?: string;
 }
 
-function replacePlaceholders(text: string, data: Record<string, string>): string {
+export function replacePlaceholders(text: string, data: Record<string, string>): string {
   return text.replace(/\{(\w+)(?:\|([^}]*))?\}/g, (match, key, fallback) => {
     const value = data[key];
     
@@ -59,9 +59,9 @@ function replacePlaceholders(text: string, data: Record<string, string>): string
   });
 }
 
-function generateHTMLContent(
-  blocks: TemplateBlock[], 
-  mockData: Record<string, string>, 
+export function generateHTMLContent(
+  blocks: TemplateBlock[],
+  mockData: Record<string, string>,
   subject: string,
   preheader?: string,
   organizationSettings?: any,

--- a/supabase/functions/tests/send-template-email.test.ts
+++ b/supabase/functions/tests/send-template-email.test.ts
@@ -1,0 +1,60 @@
+import { assertEquals, assertStringIncludes } from "std/testing/asserts.ts";
+import {
+  generateHTMLContent,
+  replacePlaceholders
+} from "../send-template-email/index.ts";
+
+Deno.test("replacePlaceholders handles fallbacks and sanitization", () => {
+  const data = {
+    first_name: "Jordan",
+    missing_value: "",
+    session_location: "Studio",
+    customer_phone: ""
+  };
+
+  const result = replacePlaceholders(
+    "Hi {first_name}, meet at {session_location} ({customer_phone|no phone}) {missing_value|fallback}",
+    data
+  );
+
+  assertEquals(result, "Hi Jordan, meet at - (no phone) fallback");
+});
+
+Deno.test("generateHTMLContent renders sorted blocks with placeholders", () => {
+  const html = generateHTMLContent(
+    [
+      {
+        id: "2",
+        type: "text",
+        order: 2,
+        data: {
+          content: "See you at {session_location}",
+          formatting: { alignment: "center", fontFamily: "Helvetica" }
+        }
+      },
+      {
+        id: "1",
+        type: "text",
+        order: 1,
+        data: {
+          content: "Hello {first_name}!",
+          formatting: { fontSize: "h2", bold: true }
+        }
+      }
+    ],
+    {
+      first_name: "Jordan",
+      session_location: "Beach"
+    },
+    "Reminder for {first_name}",
+    "Don't forget {first_name}",
+    { photography_business_name: "Lumiso" },
+    false
+  );
+
+  assertStringIncludes(html, "<title>Reminder for Jordan</title>");
+  const firstIndex = html.indexOf("Hello Jordan!");
+  const secondIndex = html.indexOf("See you at Beach");
+  assertEquals(firstIndex < secondIndex, true);
+  assertStringIncludes(html, "Don't forget Jordan");
+});

--- a/supabase/functions/tests/workflow-executor.test.ts
+++ b/supabase/functions/tests/workflow-executor.test.ts
@@ -1,0 +1,418 @@
+import { assert, assertEquals } from "std/testing/asserts.ts";
+import {
+  createWorkflowExecutor,
+  evaluateTriggerConditions,
+  triggerWorkflows,
+  WorkflowExecutorDeps
+} from "../workflow-executor/index.ts";
+
+type WorkflowRow = {
+  id: string;
+  trigger_type: string;
+  trigger_entity_type: string;
+  organization_id: string;
+  is_active: boolean;
+  trigger_conditions?: Record<string, unknown> | null;
+};
+
+type WorkflowExecutionRow = {
+  id: string;
+  workflow_id: string;
+  trigger_entity_type: string;
+  trigger_entity_id: string;
+  status: string;
+  created_at: string;
+  execution_log?: Array<{ trigger_data?: Record<string, unknown> }>;
+};
+
+interface SupabaseStubConfig {
+  workflows?: WorkflowRow[];
+  workflowExecutions?: WorkflowExecutionRow[];
+  organizationSettings?: Record<string, unknown>;
+  functionResponses?: Record<string, { data?: unknown; error?: unknown }>;
+}
+
+class SelectBuilder {
+  #rows: any[];
+  #filters: Array<(row: any) => boolean> = [];
+  #orderField: string | null = null;
+  #limitCount: number | null = null;
+  #singleMode: "single" | "maybe" | null = null;
+
+  constructor(rows: any[]) {
+    this.#rows = rows;
+  }
+
+  select(_columns?: string) {
+    return this;
+  }
+
+  eq(field: string, value: unknown) {
+    this.#filters.push(row => row?.[field] === value);
+    return this;
+  }
+
+  in(field: string, values: unknown[]) {
+    this.#filters.push(row => values.includes(row?.[field]));
+    return this;
+  }
+
+  gte(field: string, value: string) {
+    this.#filters.push(row => {
+      const rowValue = row?.[field];
+      return typeof rowValue === "string" ? rowValue >= value : false;
+    });
+    return this;
+  }
+
+  lt(field: string, value: string) {
+    this.#filters.push(row => {
+      const rowValue = row?.[field];
+      return typeof rowValue === "string" ? rowValue < value : false;
+    });
+    return this;
+  }
+
+  order(field: string) {
+    this.#orderField = field;
+    return this;
+  }
+
+  limit(count: number) {
+    this.#limitCount = count;
+    const { data, error } = this.#build();
+    return Promise.resolve({ data: data.slice(0, count), error });
+  }
+
+  maybeSingle() {
+    this.#singleMode = "maybe";
+    return this.then(result => result);
+  }
+
+  single() {
+    this.#singleMode = "single";
+    return this.then(result => result);
+  }
+
+  then<TResult1 = any, TResult2 = never>(
+    onfulfilled?: ((value: { data: any; error: null }) => TResult1 | Promise<TResult1>) | undefined,
+    onrejected?: ((reason: any) => TResult2 | Promise<TResult2>) | undefined
+  ): Promise<TResult1 | TResult2> {
+    return Promise.resolve(this.#build()).then(onfulfilled, onrejected);
+  }
+
+  #build() {
+    let data = this.#rows.filter(row => this.#filters.every(filter => filter(row)));
+
+    if (this.#orderField) {
+      const orderKey = this.#orderField;
+      data = [...data].sort((a, b) => {
+        const av = a?.[orderKey];
+        const bv = b?.[orderKey];
+        if (typeof av === "number" && typeof bv === "number") {
+          return av - bv;
+        }
+        return String(av ?? "").localeCompare(String(bv ?? ""));
+      });
+    }
+
+    if (this.#singleMode) {
+      const value = data[0] ?? null;
+      return { data: value, error: null };
+    }
+
+    if (this.#limitCount !== null) {
+      data = data.slice(0, this.#limitCount);
+    }
+
+    return { data, error: null };
+  }
+}
+
+function createSupabaseStub(config: SupabaseStubConfig = {}) {
+  const insertedExecutions: any[] = [];
+  const rpcCalls: Array<{ name: string; args: unknown }> = [];
+  const functionInvocations: Array<{ name: string; options: unknown }> = [];
+  const notifications: any[] = [];
+  let executionCounter = 1;
+
+  return {
+    rpc(name: string, args: unknown) {
+      rpcCalls.push({ name, args });
+      return Promise.resolve({ error: null });
+    },
+    functions: {
+      invoke(name: string, options: unknown) {
+        functionInvocations.push({ name, options });
+        const override = config.functionResponses?.[name];
+        if (override) {
+          return Promise.resolve(override);
+        }
+        return Promise.resolve({ data: { id: "email-1" }, error: null });
+      }
+    },
+    from(table: string) {
+      if (table === "workflows") {
+        return new SelectBuilder(config.workflows ?? []);
+      }
+
+      if (table === "workflow_executions") {
+        const existing = config.workflowExecutions ?? [];
+        return {
+          select(_columns?: string) {
+            return new SelectBuilder(existing);
+          },
+          insert(value: any) {
+            const payload = Array.isArray(value) ? value[0] : value;
+            const record = { id: `exec-${executionCounter++}`, ...payload };
+            insertedExecutions.push(record);
+            return {
+              select() {
+                return {
+                  single() {
+                    return Promise.resolve({ data: record, error: null });
+                  }
+                };
+              }
+            };
+          },
+          update(_value: any) {
+            return {
+              eq(_field: string, _value: unknown) {
+                return Promise.resolve({ data: null, error: null });
+              }
+            };
+          }
+        };
+      }
+
+      if (table === "organization_settings") {
+        const rows = config.organizationSettings ? [config.organizationSettings] : [{
+          photography_business_name: "Lumiso",
+          date_format: "DD/MM/YYYY",
+          time_format: "12-hour"
+        }];
+        return new SelectBuilder(rows);
+      }
+
+      if (table === "notifications") {
+        return {
+          insert(value: any) {
+            const payload = Array.isArray(value) ? value[0] : value;
+            notifications.push(payload);
+            return Promise.resolve({ error: null });
+          }
+        };
+      }
+
+      return new SelectBuilder([]);
+    },
+    auth: {
+      admin: {
+        getUserById(userId: string) {
+          return Promise.resolve({
+            data: { user: { id: userId, email: "client@example.com" } },
+            error: null
+          });
+        }
+      }
+    },
+    _state: {
+      insertedExecutions,
+      rpcCalls,
+      functionInvocations,
+      notifications
+    }
+  };
+}
+
+Deno.test("triggerWorkflows filters to workflow_id and schedules reminders", async () => {
+  const supabase = createSupabaseStub({
+    workflows: [
+      {
+        id: "wf-1",
+        trigger_type: "session_scheduled",
+        trigger_entity_type: "session",
+        organization_id: "org-1",
+        is_active: true
+      },
+      {
+        id: "wf-2",
+        trigger_type: "session_scheduled",
+        trigger_entity_type: "session",
+        organization_id: "org-1",
+        is_active: true
+      }
+    ],
+    organizationSettings: {
+      photography_business_name: "Studio",
+      date_format: "YYYY-MM-DD",
+      time_format: "24-hour"
+    }
+  });
+
+  const triggerData = {
+    trigger_type: "session_scheduled",
+    trigger_entity_type: "session",
+    trigger_entity_id: "session-1",
+    trigger_data: {
+      workflow_id: "wf-1",
+      session_data: {
+        session_date: "2024-05-01",
+        session_time: "14:30",
+        location: "Studio",
+        notes: "Bring props"
+      },
+      lead_data: {
+        name: "Jordan",
+        email: "client@example.com",
+        phone: "555-0000"
+      }
+    },
+    organization_id: "org-1"
+  };
+
+  const executed: string[] = [];
+  const result = await triggerWorkflows(
+    supabase,
+    triggerData,
+    async (_client, executionId) => {
+      executed.push(executionId);
+    }
+  );
+
+  assertEquals(result.triggered_workflows, 1);
+  assertEquals(executed.length, 1);
+  assertEquals(supabase._state.insertedExecutions.length, 1);
+  assertEquals(supabase._state.insertedExecutions[0].workflow_id, "wf-1");
+  assertEquals(supabase._state.rpcCalls, [
+    { name: "schedule_session_reminders", args: { session_id_param: "session-1" } }
+  ]);
+  assertEquals(supabase._state.functionInvocations.length, 1);
+});
+
+Deno.test("triggerWorkflows skips recent duplicates", async () => {
+  const supabase = createSupabaseStub({
+    workflows: [
+      {
+        id: "wf-1",
+        trigger_type: "session_scheduled",
+        trigger_entity_type: "session",
+        organization_id: "org-1",
+        is_active: true
+      }
+    ],
+    workflowExecutions: [
+      {
+        id: "exec-existing",
+        workflow_id: "wf-1",
+        trigger_entity_type: "session",
+        trigger_entity_id: "session-1",
+        status: "completed",
+        created_at: new Date().toISOString(),
+        execution_log: [
+          {
+            trigger_data: {
+              reminder_type: "auto",
+              status_change: null,
+              date_change: null
+            }
+          }
+        ]
+      }
+    ]
+  });
+
+  const triggerData = {
+    trigger_type: "session_scheduled",
+    trigger_entity_type: "session",
+    trigger_entity_id: "session-1",
+    trigger_data: {
+      reminder_type: "auto",
+      status_change: null,
+      date_change: null,
+      session_data: {
+        session_date: "2024-05-01",
+        session_time: "14:30",
+        location: "Studio",
+        notes: ""
+      },
+      lead_data: {
+        name: "Jordan",
+        email: "client@example.com",
+        phone: "555-0000"
+      }
+    },
+    organization_id: "org-1"
+  };
+
+  const result = await triggerWorkflows(
+    supabase,
+    triggerData,
+    async () => {
+      throw new Error("should not execute steps for duplicates");
+    }
+  );
+
+  assertEquals(result.triggered_workflows, 0);
+  assertEquals(supabase._state.insertedExecutions.length, 0);
+});
+
+Deno.test("createWorkflowExecutor dispatches actions", async () => {
+  const triggerCalls: unknown[] = [];
+  const executeCalls: unknown[] = [];
+
+  const deps: WorkflowExecutorDeps = {
+    createClient: () => ({} as any),
+    triggerWorkflowsImpl: async (_client, payload) => {
+      triggerCalls.push(payload);
+      return { triggered_workflows: 1 };
+    },
+    executeWorkflowStepsImpl: async (_client, executionId) => {
+      executeCalls.push(executionId);
+      return { executed_steps: 2 };
+    }
+  };
+
+  const handler = createWorkflowExecutor(deps);
+
+  const triggerResponse = await handler(new Request("https://example.com", {
+    method: "POST",
+    body: JSON.stringify({
+      action: "trigger",
+      trigger_type: "session_scheduled",
+      trigger_entity_type: "session",
+      trigger_entity_id: "session-1",
+      trigger_data: {},
+      organization_id: "org-1"
+    })
+  }));
+
+  assertEquals(triggerResponse.status, 200);
+  const triggerPayload = await triggerResponse.json();
+  assertEquals(triggerPayload.success, true);
+  assertEquals(triggerCalls.length, 1);
+
+  const executeResponse = await handler(new Request("https://example.com", {
+    method: "POST",
+    body: JSON.stringify({
+      action: "execute",
+      trigger_type: "session_scheduled",
+      trigger_entity_type: "session",
+      trigger_entity_id: "session-1",
+      organization_id: "org-1",
+      workflow_execution_id: "exec-123"
+    })
+  }));
+
+  assertEquals(executeResponse.status, 200);
+  const executePayload = await executeResponse.json();
+  assertEquals(executePayload.success, true);
+  assertEquals(executeCalls, ["exec-123"]);
+});
+
+Deno.test("evaluateTriggerConditions handles reminder conditions", () => {
+  assert(evaluateTriggerConditions({ reminder_type: "auto" }, { reminder_type: "auto" }));
+  assert(!evaluateTriggerConditions({ reminder_type: "auto" }, { reminder_type: "manual" }));
+  assert(evaluateTriggerConditions({}, { some: "data" }));
+});


### PR DESCRIPTION
## Summary
- add Deno tests for the workflow executor covering trigger dispatch, reminder scheduling, and duplicate prevention
- add placeholder and block-order tests for the send-template-email helper utilities
- export internal helpers and update the unit-testing plan progress snapshot and iteration log

## Testing
- deno task test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68fcbfbd658c8321b477e65550366b5b