### PR TITLE
Add Deno coverage for test callback function

### DIFF
--- a/docs/unit-testing-plan.md
+++ b/docs/unit-testing-plan.md
@@ -41,8 +41,8 @@
 | Contexts & Hooks | 24 | 24 | 100% |
 | UI Components & Pages | 30 | 30 | 100% |
 | UI Primitives & Shared Components | 13 | 13 | 100% |
-| Supabase Edge Functions & Automation | 8 | 9 | 89% |
-| **Overall** | **93** | **94** | **99%** |
+| Supabase Edge Functions & Automation | 9 | 9 | 100% |
+| **Overall** | **94** | **94** | **100%** |
 
 ### Core Libraries & Helpers
 | Area | File(s) | What to Cover | Priority | Status | Notes |
@@ -167,7 +167,7 @@
 | Template email sender | `supabase/functions/send-template-email/index.ts` | Template lookup, localization, Resend payload | High | Done | Validated via `supabase/functions/tests/send-template-email.test.ts` for placeholder fallbacks and block ordering. |
 | User email lookup | `supabase/functions/get-users-email/index.ts` | Auth enforcement, filtering, pagination | Medium | Done | Covered by `supabase/functions/tests/get-users-email.test.ts` for happy path, validation, and failure skips. |
 | Email localization helpers | `supabase/functions/_shared/email-i18n.ts` | Language normalization, fallback to EN, list helpers | Low | Done | Validated via `supabase/functions/tests/email-i18n.test.ts` for default, Turkish, and fallback behaviors. |
-| Test callback harness | `supabase/functions/test-callback/index.ts` | Echo behavior, validation of payload schema | Low | Not started | Keep as sanity check for function invocation plumbing. |
+| Test callback harness | `supabase/functions/test-callback/index.ts` | Echo behavior, validation of payload schema | Low | Done | Covered by `supabase/functions/tests/test-callback.test.ts` for CORS, metadata rendering, and error handling. |
 
 _Statuses_: `Not started`, `In progress`, `Blocked`, `Ready for review`, `Done`. Update the relevant table after every iteration that touches a listed area; add new rows when new risk surfaces.
 
@@ -245,6 +245,7 @@ _Statuses_: `Not started`, `In progress`, `Blocked`, `Ready for review`, `Done`.
 | 2025-10-30 | Codex | Added workflow executor + template email coverage | `supabase/functions/tests/workflow-executor.test.ts` validates trigger filtering, duplicate prevention, and action dispatch; `supabase/functions/tests/send-template-email.test.ts` locks placeholder fallbacks and block ordering | Next: Cover notification processor queue handling and simple daily scheduler paths |
 | 2025-10-30 (late night+++) | Codex | Added notification processor guard coverage | `supabase/functions/tests/notification-processor.test.ts` locks settings gating, retry RPC success/error, milestone forwarding, and workflow email templating | Follow up by simulating batch processing + resend failure branches |
 | 2025-10-30 (night wrap) | Codex | Added simple daily scheduler handler coverage | `supabase/functions/tests/simple-daily-notifications.test.ts` verifies empty-queue exit and bubbled fetch errors via injected supabase factory | Consider adding fixture-driven tests for timezone-aligned processing |
+| 2025-10-30 (final wrap) | Codex | Added test callback harness coverage | `supabase/functions/tests/test-callback.test.ts` covers OPTIONS CORS headers, metadata echo, and error surfacing | No follow-up; keep function as diagnostic surface |
 
 ## Maintenance Rules of Thumb
 - Treat this file like the single source of truth for unit testing status—update it in the same PR as any test additions or strategy changes.

--- a/supabase/functions/test-callback/index.ts
+++ b/supabase/functions/test-callback/index.ts
@@ -1,28 +1,14 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
+export const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
 
-serve(async (req) => {
-  // Handle CORS preflight requests
-  if (req.method === 'OPTIONS') {
-    return new Response(null, { headers: corsHeaders });
-  }
-
-  try {
-    const url = new URL(req.url);
-    
-    console.log('=== TEST CALLBACK FUNCTION ===');
-    console.log('Request method:', req.method);
-    console.log('Full URL:', req.url);
-    console.log('URL path:', url.pathname);
-    console.log('URL search params:', url.searchParams.toString());
-    console.log('All params:', Object.fromEntries(url.searchParams.entries()));
-    
-    // Return a simple HTML page with all the information
-    return new Response(`
+const template = (
+  req: Request,
+  url: URL,
+): string => `
       <html>
         <head>
           <title>Test Callback - Debug Info</title>
@@ -38,19 +24,19 @@ serve(async (req) => {
           <div class="info success">
             <h3>✅ Callback function is reachable!</h3>
           </div>
-          
+
           <div class="info">
             <h3>Request Details:</h3>
             <p><strong>Method:</strong> ${req.method}</p>
             <p><strong>URL:</strong> ${req.url}</p>
-            <p><strong>Search Params:</strong> ${url.searchParams.toString() || 'None'}</p>
+            <p><strong>Search Params:</strong> ${url.searchParams.toString() || "None"}</p>
           </div>
-          
+
           <div class="info">
             <h3>URL Parameters:</h3>
             <pre>${JSON.stringify(Object.fromEntries(url.searchParams.entries()), null, 2)}</pre>
           </div>
-          
+
           <div class="info">
             <h3>Test URLs:</h3>
             <p>Test with code parameter: <a href="?code=test123&state=teststate">Click here</a></p>
@@ -58,22 +44,45 @@ serve(async (req) => {
           </div>
         </body>
       </html>
-    `, {
-      headers: { 'Content-Type': 'text/html' },
-    });
+    `;
 
-  } catch (error) {
-    console.error('Test callback error:', error);
-    return new Response(`
+const errorTemplate = (message: string): string => `
       <html>
         <body>
           <h1>Error in Test Callback</h1>
-          <p>Error: ${error.message}</p>
+          <p>Error: ${message}</p>
         </body>
       </html>
-    `, {
-      headers: { 'Content-Type': 'text/html' },
+    `;
+
+export const handler = async (req: Request): Promise<Response> => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const url = new URL(req.url);
+
+    console.log("=== TEST CALLBACK FUNCTION ===");
+    console.log("Request method:", req.method);
+    console.log("Full URL:", req.url);
+    console.log("URL path:", url.pathname);
+    console.log("URL search params:", url.searchParams.toString());
+    console.log("All params:", Object.fromEntries(url.searchParams.entries()));
+
+    return new Response(template(req, url), {
+      headers: { "Content-Type": "text/html" },
+    });
+  } catch (error) {
+    console.error("Test callback error:", error);
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return new Response(errorTemplate(message), {
+      headers: { "Content-Type": "text/html" },
       status: 500,
     });
   }
-});
+};
+
+if (import.meta.main) {
+  serve((req: Request) => handler(req));
+}

--- a/supabase/functions/tests/test-callback.test.ts
+++ b/supabase/functions/tests/test-callback.test.ts
@@ -1,0 +1,45 @@
+import { assertEquals, assertStringIncludes } from "std/testing/asserts.ts";
+import { corsHeaders, handler } from "../test-callback/index.ts";
+
+Deno.test("handler returns CORS headers for OPTIONS requests", async () => {
+  const response = await handler(new Request("https://example.com", { method: "OPTIONS" }));
+
+  assertEquals(response.status, 200);
+  for (const [key, value] of Object.entries(corsHeaders)) {
+    assertEquals(response.headers.get(key), value);
+  }
+});
+
+Deno.test("handler renders request metadata for GET requests", async () => {
+  const response = await handler(
+    new Request("https://example.com/test-callback?code=abc123&state=my-state", { method: "GET" }),
+  );
+
+  assertEquals(response.status, 200);
+  assertEquals(response.headers.get("Content-Type"), "text/html");
+
+  const body = await response.text();
+  assertStringIncludes(body, "Test Callback Function");
+  assertStringIncludes(body, "code");
+  assertStringIncludes(body, "abc123");
+  assertStringIncludes(body, "state");
+  assertStringIncludes(body, "my-state");
+  assertStringIncludes(body, "Search Params:");
+});
+
+Deno.test("handler surfaces errors when URL parsing fails", async () => {
+  const originalURL = globalThis.URL;
+  (globalThis as unknown as { URL: typeof URL }).URL = function brokenURL() {
+    throw new Error("boom");
+  } as unknown as typeof URL;
+
+  try {
+    const response = await handler(new Request("https://example.com", { method: "GET" }));
+    assertEquals(response.status, 500);
+    const body = await response.text();
+    assertStringIncludes(body, "Error in Test Callback");
+    assertStringIncludes(body, "boom");
+  } finally {
+    (globalThis as unknown as { URL: typeof URL }).URL = originalURL;
+  }
+});


### PR DESCRIPTION
## Summary
- export the test callback handler and keep the HTML diagnostics available when deployed
- add deno-based tests that exercise CORS handling, metadata echoing, and error surfacing
- update the unit testing plan progress snapshot and iteration log to reflect full Supabase coverage

## Testing
- npm run test:deno *(fails: deno: not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fcc3c84c78832199af0f3b5f4407bb