### PR TITLE
Add LeadDetail page unit tests and update testing plan

### DIFF
--- a/docs/unit-testing-plan.md
+++ b/docs/unit-testing-plan.md
@@ -39,10 +39,10 @@
 | Core Libraries & Helpers | 13 | 13 | 100% |
 | Services & Data Access | 5 | 5 | 100% |
 | Contexts & Hooks | 24 | 24 | 100% |
-| UI Components & Pages | 30 | 30 | 100% |
+| UI Components & Pages | 27 | 33 | 82% |
 | UI Primitives & Shared Components | 13 | 13 | 100% |
 | Supabase Edge Functions & Automation | 9 | 9 | 100% |
-| **Overall** | **94** | **94** | **100%** |
+| **Overall** | **91** | **97** | **94%** |
 
 ### Core Libraries & Helpers
 | Area | File(s) | What to Cover | Priority | Status | Notes |
@@ -112,7 +112,7 @@
 | Protected route guard | `src/components/ProtectedRoute.tsx` | Auth gating, redirect logic, loading fallback | Medium | Done | Covered by `src/components/__tests__/ProtectedRoute.test.tsx` (loading/redirect + onboarding guard). |
 | Route prefetcher | `src/components/RoutePrefetcher.tsx` | Prefetch orchestration, duplicate avoidance | Medium | Done | Covered by `src/components/__tests__/RoutePrefetcher.test.tsx` (cache guard + Supabase prefetch). |
 | Offline banner | `src/components/OfflineBanner.tsx` | Connectivity context integration, retry actions | Low | Done | Covered by `src/components/__tests__/OfflineBanner.test.tsx` (online skip + retry + spinner state). |
-| Lead detail page | `src/pages/LeadDetail.tsx` | Data loading, tab switching, error fallbacks | High | Not started | Mock services + ensure skeleton vs content transitions. |
+| Lead detail page | `src/pages/LeadDetail.tsx` | Data loading, tab switching, error fallbacks | High | Done | Covered by `src/pages/__tests__/LeadDetail.test.tsx` for skeleton fallback, summary wiring, status actions, and fetch error toasts. |
 | Project detail page | `src/pages/ProjectDetail.tsx` | Combined queries, session/payment sections, modals | High | Not started | Assert page handles missing project gracefully. |
 | Calendar page | `src/pages/Calendar.tsx` | Range filters, session grouping, performance panels | High | Not started | Use fake timers to cover performance overlay toggles. |
 | Upcoming sessions page | `src/pages/UpcomingSessions.tsx` | Filters, session sorting, empty state messaging | Medium | Not started | Ensure sessions from multiple statuses render correctly. |
@@ -246,6 +246,7 @@ _Statuses_: `Not started`, `In progress`, `Blocked`, `Ready for review`, `Done`.
 | 2025-10-30 (late night+++) | Codex | Added notification processor guard coverage | `supabase/functions/tests/notification-processor.test.ts` locks settings gating, retry RPC success/error, milestone forwarding, and workflow email templating | Follow up by simulating batch processing + resend failure branches |
 | 2025-10-30 (night wrap) | Codex | Added simple daily scheduler handler coverage | `supabase/functions/tests/simple-daily-notifications.test.ts` verifies empty-queue exit and bubbled fetch errors via injected supabase factory | Consider adding fixture-driven tests for timezone-aligned processing |
 | 2025-10-30 (final wrap) | Codex | Added test callback harness coverage | `supabase/functions/tests/test-callback.test.ts` covers OPTIONS CORS headers, metadata echo, and error surfacing | No follow-up; keep function as diagnostic surface |
+| 2025-10-30 (night wrap++) | Codex | Added lead detail page coverage | `src/pages/__tests__/LeadDetail.test.tsx` locks loading skeleton, summary wiring, quick status buttons, and fetch error toasts | Next: tackle ProjectDetail page data orchestration |
 
 ## Maintenance Rules of Thumb
 - Treat this file like the single source of truth for unit testing status—update it in the same PR as any test additions or strategy changes.

--- a/src/pages/__tests__/LeadDetail.test.tsx
+++ b/src/pages/__tests__/LeadDetail.test.tsx
@@ -1,0 +1,314 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@/utils/testUtils";
+import LeadDetail from "../LeadDetail";
+import { useLeadDetailData } from "@/hooks/useLeadDetailData";
+import { toast } from "@/hooks/use-toast";
+import { useOrganizationQuickSettings } from "@/hooks/useOrganizationQuickSettings";
+import { useLeadStatusActions } from "@/hooks/useLeadStatusActions";
+import { useOnboarding } from "@/contexts/OnboardingContext";
+import { useSessionActions } from "@/hooks/useSessionActions";
+import { useParams, useNavigate, useLocation } from "react-router-dom";
+
+jest.mock("@/hooks/useLeadDetailData");
+jest.mock("@/hooks/use-toast", () => ({ toast: jest.fn() }));
+jest.mock("@/hooks/useOrganizationQuickSettings", () => ({
+  useOrganizationQuickSettings: jest.fn(),
+}));
+jest.mock("@/hooks/useLeadStatusActions", () => ({
+  useLeadStatusActions: jest.fn(),
+}));
+jest.mock("@/contexts/OnboardingContext", () => ({
+  useOnboarding: jest.fn(),
+}));
+jest.mock("@/hooks/useSessionActions", () => ({
+  useSessionActions: jest.fn(),
+}));
+
+const createTranslator = () =>
+  jest.fn((key: string, options?: Record<string, unknown>) => {
+    if (options && (options as any).returnObjects) {
+      if (key.includes("intro.sections")) {
+        return [
+          { title: "Intro One", description: "Intro description" },
+          { title: "Intro Two", description: "More intro" },
+        ];
+      }
+
+      if (key.includes("exploreProjects.points")) {
+        return ["point-a", "point-b"];
+      }
+
+      if (key.includes("scheduleSession.sections")) {
+        return [
+          { title: "Schedule", description: "Pick time" },
+          { title: "Confirm", description: "Confirm details" },
+        ];
+      }
+
+      if (key.includes("sessionScheduled.tips")) {
+        return ["tip-a", "tip-b"];
+      }
+    }
+
+    return options ? `${key}:${JSON.stringify(options)}` : key;
+  });
+
+const translatorMock = createTranslator();
+const formsTranslatorMock = createTranslator();
+const commonTranslatorMock = createTranslator();
+
+jest.mock("@/hooks/useTypedTranslation", () => ({
+  useMessagesTranslation: () => ({ t: translatorMock }),
+  useFormsTranslation: () => ({ t: formsTranslatorMock }),
+  useCommonTranslation: () => ({ t: commonTranslatorMock }),
+}));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: createTranslator() }),
+}));
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useParams: jest.fn(),
+  useNavigate: jest.fn(),
+  useLocation: jest.fn(),
+}));
+
+const mockUseLeadDetailData = useLeadDetailData as jest.MockedFunction<
+  typeof useLeadDetailData
+>;
+const mockToast = toast as jest.Mock;
+const mockUseOrganizationQuickSettings =
+  useOrganizationQuickSettings as jest.MockedFunction<
+    typeof useOrganizationQuickSettings
+  >;
+const mockUseLeadStatusActions = useLeadStatusActions as jest.MockedFunction<
+  typeof useLeadStatusActions
+>;
+const mockUseOnboarding = useOnboarding as jest.MockedFunction<
+  typeof useOnboarding
+>;
+const mockUseSessionActions = useSessionActions as jest.MockedFunction<
+  typeof useSessionActions
+>;
+
+const mockUseParams = useParams as jest.Mock;
+const mockUseNavigate = useNavigate as jest.Mock;
+const mockUseLocation = useLocation as jest.Mock;
+
+const entityHeaderSpy = jest.fn();
+const projectsSectionSpy = jest.fn();
+const leadActivitySpy = jest.fn();
+let markAsCompletedMock: jest.Mock;
+let markAsLostMock: jest.Mock;
+
+jest.mock("@/components/EntityHeader", () => ({
+  EntityHeader: (props: any) => {
+    entityHeaderSpy(props);
+    return (
+      <div data-testid="entity-header">
+        <div data-testid="entity-actions">{props.actions}</div>
+      </div>
+    );
+  },
+}));
+
+jest.mock("@/components/ProjectsSection", () => ({
+  ProjectsSection: (props: any) => {
+    projectsSectionSpy(props);
+    return <div data-testid="projects-section" />;
+  },
+}));
+
+jest.mock("@/components/LeadActivitySection", () => ({
+  LeadActivitySection: (props: any) => {
+    leadActivitySpy(props);
+    return <div data-testid="lead-activity" />;
+  },
+}));
+
+jest.mock("@/components/ScheduleSessionDialog", () => ({
+  __esModule: true,
+  default: (props: any) => {
+    return (
+      <button
+        data-testid="schedule-session"
+        onClick={() => props.onSessionScheduled?.()}
+      >
+        schedule
+      </button>
+    );
+  },
+}));
+
+jest.mock("@/components/EditSessionDialog", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("@/components/LeadStatusBadge", () => ({
+  LeadStatusBadge: () => <div data-testid="lead-status-badge" />,
+}));
+
+jest.mock("@/components/UnifiedClientDetails", () => ({
+  UnifiedClientDetails: () => <div data-testid="client-details" />,
+}));
+
+jest.mock("@/components/project-details/ProjectDetailsLayout", () => ({
+  __esModule: true,
+  default: ({ left, sections, rightFooter }: any) => (
+    <div data-testid="project-details-layout">
+      <div data-testid="layout-left">{left}</div>
+      <div data-testid="layout-sections">
+        {sections.map((section: any) => (
+          <div key={section.id} data-testid={`section-${section.id}`}>
+            <div>{section.title}</div>
+            <div>{section.content}</div>
+          </div>
+        ))}
+      </div>
+      <div data-testid="layout-footer">{rightFooter}</div>
+    </div>
+  ),
+}));
+
+jest.mock("@/components/shared/OnboardingTutorial", () => ({
+  OnboardingTutorial: () => null,
+}));
+
+jest.mock("@/components/ui/loading-presets", () => ({
+  DetailPageLoadingSkeleton: () => <div data-testid="lead-detail-loading" />,
+}));
+
+function createLeadDetailResponse(
+  overrides: Partial<ReturnType<typeof useLeadDetailData>> = {}
+) {
+  const base = {
+    lead: {
+      id: "lead-1",
+      name: "Test Lead",
+      status: "New",
+      status_id: "status-1",
+      created_at: "2024-01-01T00:00:00Z",
+    },
+    leadQuery: { isError: false, isSuccess: true, error: null, refetch: jest.fn() },
+    sessions: [] as any[],
+    sessionsQuery: { refetch: jest.fn(), data: [], isFetching: false },
+    projectSummary: { count: 0, latestUpdate: null },
+    aggregatedPayments: { total: 0, totalPaid: 0, remaining: 0, currency: "TRY" },
+    summaryQuery: { refetch: jest.fn() },
+    latestLeadActivity: null,
+    latestActivityQuery: { refetch: jest.fn() },
+    leadStatuses: [
+      { id: "status-completed", name: "Completed", is_system_final: true },
+      { id: "status-lost", name: "Lost", is_system_final: true },
+    ],
+    sessionMetrics: {
+      todayCount: 0,
+      todayNext: null,
+      nextUpcoming: null,
+      overdueCount: 0,
+    },
+    latestSessionUpdate: null,
+    hasProjects: false,
+    isLoading: false,
+    refetchAll: jest.fn(),
+  } as any;
+
+  return { ...base, ...overrides };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  mockUseParams.mockReturnValue({ id: "lead-1" });
+  mockUseNavigate.mockReturnValue(jest.fn());
+  mockUseLocation.mockReturnValue({ state: {} });
+
+  mockUseOrganizationQuickSettings.mockReturnValue({
+    settings: { show_quick_status_buttons: true },
+    loading: false,
+  });
+
+  markAsCompletedMock = jest.fn();
+  markAsLostMock = jest.fn();
+  mockUseLeadStatusActions.mockReturnValue({
+    markAsCompleted: markAsCompletedMock,
+    markAsLost: markAsLostMock,
+    isUpdating: false,
+  });
+
+  mockUseOnboarding.mockReturnValue({
+    currentStep: 0,
+    completeCurrentStep: jest.fn(),
+    completeMultipleSteps: jest.fn(),
+  });
+
+  mockUseSessionActions.mockReturnValue({ deleteSession: jest.fn() });
+});
+
+describe("LeadDetail", () => {
+  it("renders loading skeleton while data is loading", () => {
+    mockUseLeadDetailData.mockReturnValue(
+      createLeadDetailResponse({
+        isLoading: true,
+      })
+    );
+
+    render(<LeadDetail />);
+
+    expect(screen.getByTestId("lead-detail-loading")).toBeInTheDocument();
+    expect(entityHeaderSpy).not.toHaveBeenCalled();
+  });
+
+  it("renders lead content and summary once data loads", () => {
+    const response = createLeadDetailResponse();
+    mockUseLeadDetailData.mockReturnValue(response);
+
+    render(<LeadDetail />);
+
+    expect(screen.getByTestId("entity-header")).toBeInTheDocument();
+    const summaryItems = entityHeaderSpy.mock.calls[0][0].summaryItems;
+    expect(summaryItems).toHaveLength(4);
+    expect(summaryItems[0].primary).toBe("leadDetail.header.projects.none");
+    expect(summaryItems[1].primary).toBe("leadDetail.header.payments.primaryZero");
+    expect(summaryItems[2].primary).toBe("leadDetail.header.sessions.none");
+    expect(summaryItems[3].primary).toBe("leadDetail.header.activity.none");
+
+    expect(projectsSectionSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ leadId: "lead-1", leadName: "Test Lead" })
+    );
+    expect(leadActivitySpy).toHaveBeenCalledWith(
+      expect.objectContaining({ leadId: "lead-1", leadName: "Test Lead" })
+    );
+
+    fireEvent.click(screen.getByText("Completed"));
+    fireEvent.click(screen.getByText("Lost"));
+    expect(markAsCompletedMock).toHaveBeenCalledTimes(1);
+    expect(markAsLostMock).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByTestId("schedule-session"));
+    expect(response.refetchAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces fetch errors and navigates back to lead list", async () => {
+    const navigate = jest.fn();
+    mockUseNavigate.mockReturnValue(navigate);
+    mockUseLeadDetailData.mockReturnValue(
+      createLeadDetailResponse({
+        lead: null,
+        isLoading: false,
+        leadQuery: { isError: true, isSuccess: false, error: new Error("Boom") },
+      })
+    );
+
+    render(<LeadDetail />);
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "leadDetail.toast.fetchLeadTitle" })
+      );
+      expect(navigate).toHaveBeenCalledWith("/leads");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest coverage for the LeadDetail page to validate loading fallback, summary wiring, status actions, and fetch error handling
- refresh docs/unit-testing-plan.md progress snapshot and iteration log to record the new page coverage

## Testing
- npm test -- LeadDetail

------
https://chatgpt.com/codex/tasks/task_e_68fcc4d8acd483219be178539f2f40e5