### PR TITLE
Add tests for Calendar and UpcomingSessions pages

### DIFF
--- a/docs/unit-testing-plan.md
+++ b/docs/unit-testing-plan.md
@@ -39,10 +39,10 @@
 | Core Libraries & Helpers | 13 | 13 | 100% |
 | Services & Data Access | 5 | 5 | 100% |
 | Contexts & Hooks | 24 | 24 | 100% |
-| UI Components & Pages | 29 | 43 | 67% |
+| UI Components & Pages | 31 | 43 | 72% |
 | UI Primitives & Shared Components | 13 | 13 | 100% |
 | Supabase Edge Functions & Automation | 9 | 9 | 100% |
-| **Overall** | **93** | **107** | **87%** |
+| **Overall** | **95** | **107** | **89%** |
 
 ### Core Libraries & Helpers
 | Area | File(s) | What to Cover | Priority | Status | Notes |
@@ -119,8 +119,8 @@
 | Analytics dashboard page | `src/pages/Analytics.tsx` | Session metric toggles, Supabase aggregation fallbacks, chart data transforms | Medium | Not started | Stub analytics queries to confirm scheduled vs created toggles, empty states, and failure toasts. |
 | Workflows management page | `src/pages/Workflows.tsx` | Filtering, KPI summaries, pagination, toggle actions | High | Not started | Mock `useWorkflows` to assert status filters, load-more pagination, KPI card counts, and toggle/CRUD dialog wiring. |
 | Session detail page | `src/pages/SessionDetail.tsx` | Supabase fetch path, edit/delete flows, navigation fallback | High | Not started | Validate skeleton-to-content transition, delete success redirect, and error toast on fetch failure. |
-| Calendar page | `src/pages/Calendar.tsx` | Range filters, session grouping, performance panels | High | Not started | Use fake timers to cover performance overlay toggles. |
-| Upcoming sessions page | `src/pages/UpcomingSessions.tsx` | Filters, session sorting, empty state messaging | Medium | Not started | Ensure sessions from multiple statuses render correctly. |
+| Calendar page | `src/pages/Calendar.tsx` | Range filters, session grouping, performance panels | High | Done | Covered by `src/pages/__tests__/Calendar.test.tsx` validating skeleton loading, segmented view switching, and session sheet launch. |
+| Upcoming sessions page | `src/pages/UpcomingSessions.tsx` | Filters, session sorting, empty state messaging | Medium | Done | Covered by `src/pages/__tests__/UpcomingSessions.test.tsx` confirming KPI metrics, segment filters, and session sheet navigation. |
 | Templates workspace | `src/pages/Templates.tsx` | Block editor integration, preview data toggles | Medium | Not started | Mock template utils + i18n to confirm fallback content. |
 | Session types settings | `src/components/SessionTypesSection.tsx` | CRUD workflows, default selection, empty states | High | Done | Covered by `src/components/__tests__/SessionTypesSection.test.tsx` (empty state, default toggle, activation toggle, deletion). |
 | Session form fields | `src/components/SessionFormFields.tsx` | Validation messaging, timezone-aware inputs, reminders toggles | Medium | Done | Covered by `src/components/__tests__/SessionFormFields.test.tsx` (project selector + field callbacks). |
@@ -258,6 +258,7 @@ _Statuses_: `Not started`, `In progress`, `Blocked`, `Ready for review`, `Done`.
 | 2025-10-30 (final wrap) | Codex | Added test callback harness coverage | `supabase/functions/tests/test-callback.test.ts` covers OPTIONS CORS headers, metadata echo, and error surfacing | No follow-up; keep function as diagnostic surface |
 | 2025-10-30 (night wrap++) | Codex | Added lead detail page coverage | `src/pages/__tests__/LeadDetail.test.tsx` locks loading skeleton, summary wiring, quick status buttons, and fetch error toasts | Next: tackle ProjectDetail page data orchestration |
 | 2025-10-31 | Codex | Added Project detail page coverage | `src/pages/__tests__/ProjectDetail.test.tsx` exercises successful fetch composition and missing-project redirect toast | Next: Cover Calendar and UpcomingSessions pages |
+| 2025-10-31 (later still) | Codex | Added Calendar and Upcoming Sessions page coverage | `src/pages/__tests__/Calendar.test.tsx` and `src/pages/__tests__/UpcomingSessions.test.tsx` lock view toggles, KPI metrics, segment filtering, and session sheet navigation | Next: Tackle AllProjects workspace sorting/export flows |
 
 ## Maintenance Rules of Thumb
 - Treat this file like the single source of truth for unit testing status—update it in the same PR as any test additions or strategy changes.

--- a/src/pages/__tests__/Calendar.test.tsx
+++ b/src/pages/__tests__/Calendar.test.tsx
@@ -1,0 +1,218 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@/utils/testUtils";
+import Calendar from "../Calendar";
+import { useOptimizedCalendarData } from "@/hooks/useOptimizedCalendarData";
+import { useOptimizedCalendarViewport } from "@/hooks/useOptimizedCalendarViewport";
+import { useOptimizedCalendarNavigation } from "@/hooks/useOptimizedCalendarNavigation";
+import { useOptimizedCalendarEvents } from "@/hooks/useOptimizedCalendarEvents";
+import { useOptimizedTouchHandlers } from "@/hooks/useOptimizedTouchHandlers";
+import { useCalendarPerformanceMonitor } from "@/hooks/useCalendarPerformanceMonitor";
+import { useOrganizationSettings } from "@/hooks/useOrganizationSettings";
+import { useThrottledRefetchOnFocus } from "@/hooks/useThrottledRefetchOnFocus";
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock("@/components/ui/segmented-control", () => ({
+  SegmentedControl: ({ value, onValueChange, options }: any) => (
+    <div data-testid="segmented-control" data-value={value}>
+      {options.map((option: any) => (
+        <button
+          key={option.value}
+          type="button"
+          data-testid={`segment-${option.value}`}
+          onClick={() => onValueChange(option.value)}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+jest.mock("@/components/calendar/CalendarSkeleton", () => ({
+  CalendarSkeleton: () => <div data-testid="calendar-skeleton" />,
+  CalendarWeekSkeleton: () => <div data-testid="calendar-week-skeleton" />,
+  CalendarDaySkeleton: () => <div data-testid="calendar-day-skeleton" />,
+}));
+
+const monthViewMock = jest.fn(() => <div data-testid="calendar-month-view">Month View</div>);
+const weekViewMock = jest.fn(() => <div data-testid="calendar-week-view">Week View</div>);
+const dayViewMock = jest.fn(({ onSessionClick }: any) => (
+  <button
+    type="button"
+    data-testid="calendar-day-view"
+    onClick={() =>
+      onSessionClick &&
+      onSessionClick({
+        id: "session-123",
+        session_date: "2024-05-01",
+        session_time: "10:00",
+        status: "active",
+        lead_id: "lead-1",
+      })
+    }
+  >
+    Day View
+  </button>
+));
+
+jest.mock("@/components/calendar/CalendarMonthView", () => ({
+  CalendarMonthView: (props: any) => monthViewMock(props),
+}));
+
+jest.mock("@/components/calendar/CalendarWeek", () => ({
+  CalendarWeek: (props: any) => weekViewMock(props),
+}));
+
+jest.mock("@/components/calendar/CalendarDayView", () => ({
+  CalendarDayView: (props: any) => dayViewMock(props),
+}));
+
+jest.mock("@/components/ProjectSheetView", () => ({
+  ProjectSheetView: ({ project, open }: any) =>
+    open ? <div data-testid="project-sheet">{project?.id}</div> : null,
+}));
+
+const sessionSheetMock = jest.fn(({ sessionId, isOpen, onOpenChange }: any) =>
+  isOpen ? (
+    <div data-testid="session-sheet">
+      Session Sheet: {sessionId}
+      <button type="button" onClick={() => onOpenChange(false)}>
+        Close
+      </button>
+    </div>
+  ) : null,
+);
+
+jest.mock("@/components/SessionSheetView", () => ({
+  __esModule: true,
+  default: (props: any) => sessionSheetMock(props),
+}));
+
+jest.mock("@/components/calendar/CalendarErrorBoundary", () => ({
+  CalendarErrorWrapper: ({ children }: any) => <>{children}</>,
+}));
+
+jest.mock("@/hooks/useOptimizedCalendarData");
+jest.mock("@/hooks/useOptimizedCalendarViewport");
+jest.mock("@/hooks/useOptimizedCalendarNavigation");
+jest.mock("@/hooks/useOptimizedCalendarEvents");
+jest.mock("@/hooks/useOptimizedTouchHandlers");
+jest.mock("@/hooks/useCalendarPerformanceMonitor");
+jest.mock("@/hooks/useOrganizationSettings");
+jest.mock("@/hooks/useThrottledRefetchOnFocus");
+
+const mockUseOptimizedCalendarData = useOptimizedCalendarData as jest.Mock;
+const mockUseOptimizedCalendarViewport = useOptimizedCalendarViewport as jest.Mock;
+const mockUseOptimizedCalendarNavigation = useOptimizedCalendarNavigation as jest.Mock;
+const mockUseOptimizedCalendarEvents = useOptimizedCalendarEvents as jest.Mock;
+const mockUseOptimizedTouchHandlers = useOptimizedTouchHandlers as jest.Mock;
+const mockUseCalendarPerformanceMonitor = useCalendarPerformanceMonitor as jest.Mock;
+const mockUseOrganizationSettings = useOrganizationSettings as jest.Mock;
+const mockUseThrottledRefetchOnFocus = useThrottledRefetchOnFocus as jest.Mock;
+
+const createBaseHookResponse = (overrides: Partial<ReturnType<typeof useOptimizedCalendarData>> = {}) => ({
+  sessions: [],
+  activities: [],
+  projects: [],
+  leads: [],
+  projectsMap: {},
+  leadsMap: {},
+  isLoading: false,
+  error: null,
+  ...overrides,
+});
+
+describe("Calendar page", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    Object.defineProperty(window, "innerWidth", {
+      value: 1024,
+      writable: true,
+    });
+
+    mockUseOptimizedCalendarData.mockReturnValue(createBaseHookResponse());
+    mockUseOptimizedCalendarViewport.mockReturnValue({
+      isMobile: false,
+      isTablet: false,
+      isDesktop: true,
+      viewConfig: { enableSwipeNavigation: false },
+      handleDayClick: jest.fn(),
+    });
+    mockUseOptimizedCalendarNavigation.mockReturnValue({
+      navigatePrevious: jest.fn(),
+      navigateNext: jest.fn(),
+      goToToday: jest.fn(),
+      viewTitle: "May 2024",
+      handleKeyboardNavigation: jest.fn(),
+    });
+    mockUseOptimizedCalendarEvents.mockReturnValue({
+      getEventsForDate: jest.fn(() => []),
+      eventStats: { totalEvents: 0 },
+    });
+    mockUseOptimizedTouchHandlers.mockReturnValue({
+      handleTouchStart: jest.fn(),
+      handleTouchMove: jest.fn(),
+      handleTouchEnd: jest.fn(),
+    });
+    mockUseCalendarPerformanceMonitor.mockReturnValue({
+      startRenderTiming: jest.fn(),
+      endRenderTiming: jest.fn(),
+      startQueryTiming: jest.fn(),
+      endQueryTiming: jest.fn(),
+      startEventProcessing: jest.fn(),
+      endEventProcessing: jest.fn(),
+      getPerformanceSummary: jest.fn(() => ({ eventsProcessed: 0 })),
+    });
+    mockUseOrganizationSettings.mockReturnValue({ loading: false });
+    mockUseThrottledRefetchOnFocus.mockImplementation(() => {});
+  });
+
+  it("renders the loading skeleton while data is loading", () => {
+    mockUseOptimizedCalendarData.mockReturnValue(
+      createBaseHookResponse({ isLoading: true })
+    );
+
+    render(<Calendar />);
+
+    expect(screen.getByTestId("calendar-skeleton")).toBeInTheDocument();
+    expect(screen.getAllByText("calendar.title")[0]).toBeInTheDocument();
+  });
+
+  it("renders different calendar views when the view mode changes", async () => {
+    render(<Calendar />);
+
+    expect(screen.getByTestId("calendar-month-view")).toBeInTheDocument();
+
+    const [weekButton] = screen.getAllByTestId("segment-week");
+    fireEvent.click(weekButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("calendar-week-view")).toBeInTheDocument();
+    });
+
+    const [dayButton] = screen.getAllByTestId("segment-day");
+    fireEvent.click(dayButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("calendar-day-view")).toBeInTheDocument();
+    });
+  });
+
+  it("opens the session sheet when a session is selected", async () => {
+    localStorage.setItem("calendar:viewMode", "day");
+
+    render(<Calendar />);
+
+    fireEvent.click(screen.getByTestId("calendar-day-view"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("session-sheet")).toHaveTextContent("session-123");
+    });
+  });
+});

--- a/src/pages/__tests__/UpcomingSessions.test.tsx
+++ b/src/pages/__tests__/UpcomingSessions.test.tsx
@@ -1,0 +1,350 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@/utils/testUtils";
+import AllSessions from "../UpcomingSessions";
+import { supabase } from "@/integrations/supabase/client";
+import { useSessionStatuses } from "@/hooks/useOrganizationData";
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: any) => {
+      if (options?.returnObjects) {
+        return [];
+      }
+      if (options?.metric) {
+        return `${key}:${options.metric}`;
+      }
+      if (options?.total !== undefined) {
+        return `${key}:${options.total}`;
+      }
+      if (options?.today !== undefined || options?.upcoming !== undefined) {
+        return `${key}:${options.today ?? 0}/${options?.upcoming ?? 0}`;
+      }
+      if (options?.time) {
+        return `${key}:${options.time}`;
+      }
+      if (options?.count !== undefined) {
+        return `${key}:${options.count}`;
+      }
+      return key;
+    },
+    i18n: { language: "en" },
+  }),
+}));
+
+jest.mock("@/hooks/useTypedTranslation", () => ({
+  useFormsTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock("@/hooks/useThrottledRefetchOnFocus", () => ({
+  useThrottledRefetchOnFocus: jest.fn(),
+}));
+
+jest.mock("@/hooks/useOrganizationData", () => ({
+  useSessionStatuses: jest.fn(),
+}));
+
+jest.mock("@/hooks/use-toast", () => ({
+  toast: jest.fn(),
+}));
+
+jest.mock("@/components/ui/button", () => ({
+  Button: ({ children, onClick, ...rest }: any) => (
+    <button type="button" onClick={onClick} {...rest}>
+      {children}
+    </button>
+  ),
+}));
+
+const sanitizeTestId = (value: string) => value.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+
+jest.mock("@/components/ui/kpi-card", () => ({
+  KpiCard: ({ title, value, footer }: any) => (
+    <div data-testid={`kpi-${sanitizeTestId(String(title))}`}>
+      <span data-testid={`kpi-${sanitizeTestId(String(title))}-value`}>{value}</span>
+      {footer}
+    </div>
+  ),
+}));
+
+jest.mock("@/components/ui/kpi-presets", () => ({
+  getKpiIconPreset: () => ({}),
+  KPI_ACTION_BUTTON_CLASS: "kpi-action",
+}));
+
+jest.mock("@/components/ui/segmented-control", () => ({
+  SegmentedControl: ({ value, onValueChange, options }: any) => (
+    <div data-testid="segment-control" data-value={value}>
+      {options.map((option: any) => (
+        <button
+          key={option.value}
+          type="button"
+          data-testid={`segment-${option.value}`}
+          aria-label={option.ariaLabel}
+          onClick={() => onValueChange(option.value)}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+jest.mock("@/components/ui/page-header", () => ({
+  PageHeader: ({ title, subtitle, children }: any) => (
+    <div>
+      <h1>{title}</h1>
+      <p>{subtitle}</p>
+      {children}
+    </div>
+  ),
+  PageHeaderSearch: ({ children }: any) => <div>{children}</div>,
+  PageHeaderActions: ({ children }: any) => <div>{children}</div>,
+}));
+
+jest.mock("@/components/GlobalSearch", () => () => <div data-testid="global-search" />);
+
+jest.mock("@/components/NewSessionDialog", () => ({
+  __esModule: true,
+  default: ({ children }: any) => <div>{children}</div>,
+}));
+
+jest.mock("@/components/ViewProjectDialog", () => ({
+  ViewProjectDialog: ({ open, project }: any) =>
+    open ? <div data-testid="view-project-dialog">{project?.id}</div> : null,
+}));
+
+const sessionSheetMock = jest.fn(({ sessionId, isOpen, onOpenChange }: any) =>
+  isOpen ? (
+    <div data-testid="session-sheet">
+      Session Sheet {sessionId}
+      <button type="button" onClick={() => onOpenChange(false)}>
+        Close
+      </button>
+    </div>
+  ) : null,
+);
+
+jest.mock("@/components/SessionSheetView", () => ({
+  __esModule: true,
+  default: (props: any) => sessionSheetMock(props),
+}));
+
+jest.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: any) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: any) => <div>{children}</div>,
+  PopoverContent: ({ children }: any) => <div>{children}</div>,
+}));
+
+jest.mock("@/components/ui/badge", () => ({
+  Badge: ({ children }: any) => <span>{children}</span>,
+}));
+
+jest.mock("@/components/data-table", () => ({
+  AdvancedDataTable: ({
+    data,
+    columns,
+    onRowClick,
+    emptyState,
+    actions,
+  }: any) => (
+    <div>
+      <div data-testid="table-actions">{actions}</div>
+      <div data-testid="table-rows">
+        {data.length === 0
+          ? emptyState
+          : data.map((row: any) => (
+              <div
+                key={row.id}
+                data-testid={`row-${row.id}`}
+                onClick={() => onRowClick?.(row)}
+              >
+                {columns.map((column: any) => (
+                  <div key={column.id} data-testid={`cell-${row.id}-${column.id}`}>
+                    {column.render ? column.render(row) : row[column.accessorKey || column.id] || ""}
+                  </div>
+                ))}
+              </div>
+            ))}
+      </div>
+    </div>
+  ),
+}));
+
+jest.mock("xlsx/xlsx.mjs", () => ({
+  writeFileXLSX: jest.fn(),
+  utils: {
+    json_to_sheet: jest.fn(() => ({})),
+    book_new: jest.fn(() => ({})),
+    book_append_sheet: jest.fn(),
+  },
+}));
+
+const mockSupabaseFrom = supabase.from as jest.Mock;
+const mockUseSessionStatuses = useSessionStatuses as jest.Mock;
+
+const createSessionsQuery = (sessions: any[]) => {
+  let orderCalls = 0;
+  const query: any = {};
+  query.select = jest.fn(() => query);
+  query.eq = jest.fn(() => query);
+  query.order = jest.fn(() => {
+    orderCalls += 1;
+    if (orderCalls >= 2) {
+      return Promise.resolve({ data: sessions, error: null });
+    }
+    return query;
+  });
+  return query;
+};
+
+const createMaybeSingleQuery = (data: any) => {
+  const query: any = {};
+  query.select = jest.fn(() => query);
+  query.eq = jest.fn(() => query);
+  query.ilike = jest.fn(() => query);
+  query.maybeSingle = jest.fn(() => Promise.resolve({ data, error: null }));
+  return query;
+};
+
+const setSupabaseResponses = (sessions: any[], archivedStatus: any = null) => {
+  mockSupabaseFrom.mockImplementation((table: string) => {
+    if (table === "sessions") {
+      return createSessionsQuery(sessions);
+    }
+    if (table === "project_statuses") {
+      return createMaybeSingleQuery(archivedStatus);
+    }
+    const query: any = {};
+    query.select = jest.fn(() => query);
+    query.eq = jest.fn(() => query);
+    query.single = jest.fn(() => Promise.resolve({ data: null, error: null }));
+    return query;
+  });
+};
+
+describe("Upcoming sessions page", () => {
+  const RealDate = Date;
+  const fixedDate = new RealDate("2024-05-20T12:00:00.000Z");
+  const upcomingDate = new RealDate("2024-05-22T00:00:00.000Z").toISOString();
+  const pendingDate = new RealDate("2024-05-18T00:00:00.000Z").toISOString();
+  const todayDate = new RealDate("2024-05-20T00:00:00.000Z").toISOString();
+
+  beforeAll(() => {
+    class FixedDate extends RealDate {
+      constructor(...args: any[]) {
+        if (args.length === 0) {
+          super(fixedDate.toISOString());
+        } else {
+          super(...args);
+        }
+      }
+
+      static now() {
+        return fixedDate.getTime();
+      }
+    }
+
+    global.Date = FixedDate as unknown as DateConstructor;
+  });
+
+  afterAll(() => {
+    global.Date = RealDate;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseSessionStatuses.mockReturnValue({ data: [] });
+  });
+
+  const buildSessions = () => [
+    {
+      id: "session-upcoming",
+      lead_id: "lead-1",
+      session_date: upcomingDate,
+      session_time: "15:00",
+      notes: "Upcoming session",
+      status: "planned",
+      created_at: upcomingDate,
+      leads: { id: "lead-1", name: "Alice", status: "active" },
+      project_id: "project-1",
+      projects: {
+        id: "project-1",
+        name: "Wedding",
+        status_id: "status-active",
+        project_status: { id: "status-active", name: "Active", color: "#2563eb" },
+      },
+    },
+    {
+      id: "session-pending",
+      lead_id: "lead-2",
+      session_date: pendingDate,
+      session_time: "10:00",
+      notes: "Pending session",
+      status: "planned",
+      created_at: pendingDate,
+      leads: { id: "lead-2", name: "Bob", status: "active" },
+      project_id: null,
+      projects: null,
+    },
+    {
+      id: "session-today",
+      lead_id: "lead-3",
+      session_date: todayDate,
+      session_time: "09:00",
+      notes: "Today session",
+      status: "active",
+      created_at: todayDate,
+      leads: { id: "lead-3", name: "Carol", status: "active" },
+      project_id: null,
+      projects: null,
+    },
+  ];
+
+  it("renders KPI metrics and table rows after loading sessions", async () => {
+    setSupabaseResponses(buildSessions());
+
+    render(<AllSessions />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("row-session-upcoming")).toBeInTheDocument();
+      expect(screen.getByTestId("row-session-today")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("kpi-sessions-kpis-pastneedsaction-title-value")).toHaveTextContent("1");
+    expect(screen.getByTestId("kpi-sessions-kpis-schedule-title-value")).toHaveTextContent("2");
+    expect(screen.getByTestId("kpi-sessions-kpis-inprogress-title-value")).toHaveTextContent("1");
+  });
+
+  it("filters sessions when switching segments", async () => {
+    setSupabaseResponses(buildSessions());
+
+    render(<AllSessions />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("row-session-upcoming")).toBeInTheDocument();
+      expect(screen.getByTestId("row-session-pending")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("segment-pending"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("row-session-pending")).toBeInTheDocument();
+      expect(screen.queryByTestId("row-session-upcoming")).not.toBeInTheDocument();
+    });
+  });
+
+  it("opens the session sheet when a row is clicked", async () => {
+    setSupabaseResponses(buildSessions());
+
+    render(<AllSessions />);
+
+    const row = await screen.findByTestId("row-session-today");
+    fireEvent.click(row);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("session-sheet")).toHaveTextContent("session-today");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add focused unit tests for the Calendar page covering skeleton, view toggling, and session sheet behaviors
- add UpcomingSessions page tests to assert KPI metrics, segment filtering, and sheet navigation
- update the unit testing plan progress snapshot and iteration log

## Testing
- npm test -- --runTestsByPath src/pages/__tests__/Calendar.test.tsx src/pages/__tests__/UpcomingSessions.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68fcd235de088321bce0f8cc81adf030