### PR TITLE
Add WorkflowDeleteDialog tests and refresh plan metrics

### DIFF
--- a/docs/unit-testing-plan.md
+++ b/docs/unit-testing-plan.md
@@ -39,10 +39,10 @@
 | Core Libraries & Helpers | 13 | 13 | 100% |
 | Services & Data Access | 5 | 5 | 100% |
 | Contexts & Hooks | 24 | 24 | 100% |
-| UI Components & Pages | 32 | 43 | 74% |
+| UI Components & Pages | 33 | 43 | 77% |
 | UI Primitives & Shared Components | 13 | 13 | 100% |
 | Supabase Edge Functions & Automation | 9 | 9 | 100% |
-| **Overall** | **96** | **107** | **90%** |
+| **Overall** | **97** | **107** | **91%** |
 
 ### Core Libraries & Helpers
 | Area | File(s) | What to Cover | Priority | Status | Notes |
@@ -135,7 +135,7 @@
 | Activity timeline section | `src/components/ActivitySection.tsx` | Activity CRUD, reminder scheduling, filter tabs | High | Not started | Stub Supabase helpers to ensure create/edit validation, filter chips, and audit log rendering with skeleton states. |
 | Lead activity section | `src/components/LeadActivitySection.tsx` | Segmented activity/history views, cross-entity fetches, audit timeline | Medium | Not started | Mock Supabase responses to assert segment toggles, merged histories, and toast errors. |
 | Workflow creation sheet | `src/components/CreateWorkflowSheet.tsx` | Form dirty-state guard, channel toggles, template selection, create/update branching | High | Not started | Mock `useTemplates` to cover edit autopopulation, validation gating, submission callbacks, and navigation guard prompts. |
-| Workflow delete dialog | `src/components/WorkflowDeleteDialog.tsx` | Confirmation copy, destructive action wiring, disabled state | Medium | Not started | Assert translation usage, cancel vs confirm callbacks, and disabled button state while deleting. |
+| Workflow delete dialog | `src/components/WorkflowDeleteDialog.tsx` | Confirmation copy, destructive action wiring, disabled state | Medium | Done | Covered by `src/components/__tests__/WorkflowDeleteDialog.test.tsx` verifying translation text, cancel/confirm callbacks, close handling, and disabled deletion state. |
 | Project sheet preview | `src/components/ProjectSheetPreview.tsx` | Modal lifecycle, related data fetches, navigation callbacks | Medium | Not started | Verify Supabase fetch chaining, archive badge detection, and CTA handlers closing modal. |
 | Dead simple session banner | `src/components/DeadSimpleSessionBanner.tsx` | Feature flag handling, CTA availability, close persistence | Low | Done | Covered by `src/components/__tests__/DeadSimpleSessionBanner.test.tsx` checking relative badges, project labels, and click handling. |
 | Guided step progress indicator | `src/components/GuidedStepProgress.tsx` | Animation pacing, percentage calculations, copy fallback | Low | Done | Covered by `src/components/__tests__/GuidedStepProgress.test.tsx` verifying animated timer progression and non-animated target display. |
@@ -260,6 +260,7 @@ _Statuses_: `Not started`, `In progress`, `Blocked`, `Ready for review`, `Done`.
 | 2025-10-31 | Codex | Added Project detail page coverage | `src/pages/__tests__/ProjectDetail.test.tsx` exercises successful fetch composition and missing-project redirect toast | Next: Cover Calendar and UpcomingSessions pages |
 | 2025-10-31 (later still) | Codex | Added Calendar and Upcoming Sessions page coverage | `src/pages/__tests__/Calendar.test.tsx` and `src/pages/__tests__/UpcomingSessions.test.tsx` lock view toggles, KPI metrics, segment filtering, and session sheet navigation | Next: Tackle AllProjects workspace sorting/export flows |
 | 2025-11-01 | Codex | Added AllProjects workspace coverage | `src/pages/__tests__/AllProjects.test.tsx` verifies list defaults, archived toggle, quick view, and spreadsheet export success path | Next: Extend tests to cover board pagination and archived export error handling |
+| 2025-11-02 | Codex | Added workflow delete dialog coverage | `src/components/__tests__/WorkflowDeleteDialog.test.tsx` locks translation usage, cancel/confirm callbacks, close handling, and disabled deletion state | Revisit if dialog gains secondary actions or additional messaging |
 
 ## Maintenance Rules of Thumb
 - Treat this file like the single source of truth for unit testing status—update it in the same PR as any test additions or strategy changes.

--- a/src/components/__tests__/WorkflowDeleteDialog.test.tsx
+++ b/src/components/__tests__/WorkflowDeleteDialog.test.tsx
@@ -1,0 +1,147 @@
+import { act, fireEvent, render, screen } from "@/utils/testUtils";
+import { WorkflowDeleteDialog } from "../WorkflowDeleteDialog";
+import type { Workflow } from "@/types/workflow";
+import * as alertDialogModule from "@/components/ui/alert-dialog";
+import { useMessagesTranslation } from "@/hooks/useTypedTranslation";
+
+jest.mock("lucide-react", () => ({
+  AlertTriangle: (props: any) => (
+    <svg data-testid="alert-triangle" {...props} />
+  )
+}));
+
+let latestOnOpenChange: ((open: boolean) => void) | undefined;
+
+jest.mock("@/components/ui/alert-dialog", () => ({
+  __esModule: true,
+  AlertDialog: ({ open, onOpenChange, children }: any) => {
+    latestOnOpenChange = onOpenChange;
+    return (
+      <div data-testid="alert-dialog" data-open={open}>
+        {children}
+      </div>
+    );
+  },
+  AlertDialogContent: ({ children }: any) => <div>{children}</div>,
+  AlertDialogHeader: ({ children }: any) => <div>{children}</div>,
+  AlertDialogFooter: ({ children }: any) => <div>{children}</div>,
+  AlertDialogTitle: ({ children }: any) => <h2>{children}</h2>,
+  AlertDialogDescription: ({ children }: any) => <p>{children}</p>,
+  AlertDialogCancel: ({ children, onClick, disabled }: any) => (
+    <button type="button" onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+  AlertDialogAction: ({ children, onClick, disabled }: any) => (
+    <button type="button" onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+  __getOnOpenChange: () => latestOnOpenChange
+}));
+
+jest.mock("@/hooks/useTypedTranslation", () => ({
+  useMessagesTranslation: jest.fn()
+}));
+
+describe("WorkflowDeleteDialog", () => {
+  const mockWorkflow: Workflow = {
+    id: "workflow-1",
+    user_id: "user-1",
+    organization_id: "org-1",
+    name: "Onboarding Flow",
+    description: "",
+    trigger_type: "session_scheduled",
+    trigger_conditions: null,
+    is_active: true,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z"
+  };
+
+  const mockTranslator = jest.fn((key: string, options?: Record<string, unknown>) =>
+    `${key}:${options?.name ?? ""}`
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    latestOnOpenChange = undefined;
+    (useMessagesTranslation as jest.Mock).mockReturnValue({
+      t: mockTranslator
+    });
+  });
+
+  it("renders workflow name in translation message", () => {
+    render(
+      <WorkflowDeleteDialog
+        open
+        workflow={mockWorkflow}
+        onConfirm={jest.fn()}
+        onCancel={jest.fn()}
+      />
+    );
+
+    expect(mockTranslator).toHaveBeenCalledWith("confirm.deleteWithName", { name: "Onboarding Flow" });
+    expect(screen.getByText("confirm.deleteWithName:Onboarding Flow")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Delete Workflow" })).toBeInTheDocument();
+  });
+
+  it("calls onConfirm when confirm button is clicked", () => {
+    const onConfirm = jest.fn();
+
+    render(
+      <WorkflowDeleteDialog
+        open
+        workflow={mockWorkflow}
+        onConfirm={onConfirm}
+        onCancel={jest.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete Workflow" }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onCancel when cancel button is clicked and when dialog closes", () => {
+    const onCancel = jest.fn();
+
+    render(
+      <WorkflowDeleteDialog
+        open
+        workflow={mockWorkflow}
+        onConfirm={jest.fn()}
+        onCancel={onCancel}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+
+    const { __getOnOpenChange } = alertDialogModule as unknown as {
+      __getOnOpenChange: () => ((open: boolean) => void) | undefined;
+    };
+
+    act(() => {
+      __getOnOpenChange()?.(false);
+    });
+
+    expect(onCancel).toHaveBeenCalledTimes(2);
+  });
+
+  it("disables actions and updates label when deleting", () => {
+    render(
+      <WorkflowDeleteDialog
+        open
+        workflow={mockWorkflow}
+        onConfirm={jest.fn()}
+        onCancel={jest.fn()}
+        isDeleting
+      />
+    );
+
+    const cancelButton = screen.getByRole("button", { name: "Cancel" });
+    const confirmButton = screen.getByRole("button", { name: "Deleting..." });
+
+    expect(cancelButton).toBeDisabled();
+    expect(confirmButton).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit coverage for WorkflowDeleteDialog to exercise translation text, button callbacks, and disabled states
- mock alert dialog primitives to assert onOpenChange cancellation handling
- update unit-testing-plan progress snapshot, workflow delete dialog row, and iteration log entry

## Testing
- npm run test -- WorkflowDeleteDialog

------
https://chatgpt.com/codex/tasks/task_e_68fcd70295808321b2a239d5c772c84a