### PR TITLE
Add unit tests for SessionDetail page

### DIFF
--- a/docs/unit-testing-plan.md
+++ b/docs/unit-testing-plan.md
@@ -39,10 +39,10 @@
 | Core Libraries & Helpers | 13 | 13 | 100% |
 | Services & Data Access | 5 | 5 | 100% |
 | Contexts & Hooks | 24 | 24 | 100% |
-| UI Components & Pages | 36 | 43 | 84% |
+| UI Components & Pages | 37 | 43 | 86% |
 | UI Primitives & Shared Components | 13 | 13 | 100% |
 | Supabase Edge Functions & Automation | 9 | 9 | 100% |
-| **Overall** | **100** | **107** | **93%** |
+| **Overall** | **101** | **107** | **94%** |
 
 ### Core Libraries & Helpers
 | Area | File(s) | What to Cover | Priority | Status | Notes |
@@ -118,7 +118,7 @@
 | All projects workspace | `src/pages/AllProjects.tsx` | Board/list/archived view switching, tutorial gating, exports, Supabase-backed list pagination | High | Done | Covered by `src/pages/__tests__/AllProjects.test.tsx` validating view mode persistence, Kanban/list dataset sync, and CSV export error toasts. |
 | Analytics dashboard page | `src/pages/Analytics.tsx` | Session metric toggles, Supabase aggregation fallbacks, chart data transforms | Medium | Done | Covered by `src/pages/__tests__/Analytics.test.tsx` exercising scheduled/created toggles, empty datasets, and failure toast handling. |
 | Workflows management page | `src/pages/Workflows.tsx` | Filtering, KPI summaries, pagination, toggle actions | High | Done | Covered by `src/pages/__tests__/Workflows.test.tsx` validating KPI summaries, segmented filters, pagination load-more, status toggles, edit wiring, and delete confirmation. |
-| Session detail page | `src/pages/SessionDetail.tsx` | Supabase fetch path, edit/delete flows, navigation fallback | High | Not started | Validate skeleton-to-content transition, delete success redirect, and error toast on fetch failure. |
+| Session detail page | `src/pages/SessionDetail.tsx` | Supabase fetch path, edit/delete flows, navigation fallback | High | Done | Covered by `src/pages/__tests__/SessionDetail.test.tsx` validating skeleton transition, delete fallback navigation, and load error toast. |
 | Calendar page | `src/pages/Calendar.tsx` | Range filters, session grouping, performance panels | High | Done | Covered by `src/pages/__tests__/Calendar.test.tsx` validating skeleton loading, segmented view switching, and session sheet launch. |
 | Upcoming sessions page | `src/pages/UpcomingSessions.tsx` | Filters, session sorting, empty state messaging | Medium | Done | Covered by `src/pages/__tests__/UpcomingSessions.test.tsx` confirming KPI metrics, segment filters, and session sheet navigation. |
 | Templates workspace | `src/pages/Templates.tsx` | Block editor integration, preview data toggles | Medium | Not started | Mock template utils + i18n to confirm fallback content. |
@@ -261,6 +261,7 @@ _Statuses_: `Not started`, `In progress`, `Blocked`, `Ready for review`, `Done`.
 | 2025-10-31 (later still) | Codex | Added Calendar and Upcoming Sessions page coverage | `src/pages/__tests__/Calendar.test.tsx` and `src/pages/__tests__/UpcomingSessions.test.tsx` lock view toggles, KPI metrics, segment filtering, and session sheet navigation | Next: Tackle AllProjects workspace sorting/export flows |
 | 2025-11-01 | Codex | Added AllProjects workspace coverage | `src/pages/__tests__/AllProjects.test.tsx` verifies list defaults, archived toggle, quick view, and spreadsheet export success path | Next: Extend tests to cover board pagination and archived export error handling |
 | 2025-11-02 | Codex | Added workflow delete dialog coverage | `src/components/__tests__/WorkflowDeleteDialog.test.tsx` locks translation usage, cancel/confirm callbacks, close handling, and disabled deletion state | Revisit if dialog gains secondary actions or additional messaging |
+| 2025-11-03 | Codex | Added session detail page coverage | `src/pages/__tests__/SessionDetail.test.tsx` exercises skeleton-to-content transition, load failure toast, and delete redirect fallback | Next: Target Templates workspace coverage |
 
 ## Maintenance Rules of Thumb
 - Treat this file like the single source of truth for unit testing status—update it in the same PR as any test additions or strategy changes.

--- a/src/pages/__tests__/SessionDetail.test.tsx
+++ b/src/pages/__tests__/SessionDetail.test.tsx
@@ -1,0 +1,295 @@
+import { fireEvent, render, screen, waitFor } from "@/utils/testUtils";
+import { mockSupabaseClient } from "@/utils/testUtils";
+import SessionDetail from "../SessionDetail";
+import { useToast } from "@/hooks/use-toast";
+import {
+  useMessagesTranslation,
+  useCommonTranslation,
+  useFormsTranslation,
+} from "@/hooks/useTypedTranslation";
+import { useSessionActions } from "@/hooks/useSessionActions";
+
+jest.mock("@/integrations/supabase/client", () => ({
+  supabase: mockSupabaseClient,
+}));
+
+const mockNavigate = jest.fn();
+let mockLocationState: { from?: string } = {};
+
+jest.mock("react-router-dom", () => {
+  const actual = jest.requireActual("react-router-dom");
+  return {
+    ...actual,
+    useParams: () => ({ id: "session-123" }),
+    useNavigate: () => mockNavigate,
+    useLocation: () => ({ state: mockLocationState }),
+  };
+});
+
+jest.mock("@/hooks/use-toast", () => ({
+  useToast: jest.fn(),
+}));
+
+jest.mock("@/hooks/useTypedTranslation", () => ({
+  useMessagesTranslation: jest.fn(),
+  useCommonTranslation: jest.fn(),
+  useFormsTranslation: jest.fn(),
+}));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => `pages.${key}`,
+  }),
+}));
+
+jest.mock("@/hooks/useSessionActions", () => ({
+  useSessionActions: jest.fn(),
+}));
+
+jest.mock("@/components/SessionStatusBadge", () => ({
+  __esModule: true,
+  default: ({ currentStatus, onStatusChange }: any) => (
+    <button
+      type="button"
+      data-testid="session-status-badge"
+      aria-label={`status-${currentStatus}`}
+      onClick={() => onStatusChange?.("completed")}
+    >
+      status-{currentStatus}
+    </button>
+  ),
+}));
+
+jest.mock("@/components/EditSessionDialog", () => ({
+  __esModule: true,
+  default: () => <div data-testid="edit-session-dialog" />,
+}));
+
+jest.mock("@/components/ErrorBoundary", () => ({
+  __esModule: true,
+  ErrorBoundary: ({ children }: any) => <>{children}</>,
+  default: ({ children }: any) => <>{children}</>,
+}));
+
+jest.mock("@/components/UnifiedClientDetails", () => ({
+  UnifiedClientDetails: ({ lead }: any) => (
+    <div data-testid="unified-client-details">lead-{lead?.name}</div>
+  ),
+}));
+
+jest.mock("@/components/SessionGallery", () => ({
+  __esModule: true,
+  default: ({ sessionId }: any) => (
+    <div data-testid="session-gallery">gallery-{sessionId}</div>
+  ),
+}));
+
+jest.mock("@/components/EntityHeader", () => ({
+  EntityHeader: ({ name, title, onBack, actions, banner, summaryItems }: any) => (
+    <div data-testid="entity-header">
+      <h1>{name}</h1>
+      <button type="button" onClick={onBack}>
+        back
+      </button>
+      <div data-testid="entity-title">{title}</div>
+      <div data-testid="entity-actions">{actions}</div>
+      {banner ? <div data-testid="entity-banner">{banner}</div> : null}
+      <div data-testid="entity-summary">{summaryItems?.length}</div>
+    </div>
+  ),
+}));
+
+jest.mock("@/components/project-details/ProjectDetailsLayout", () => ({
+  __esModule: true,
+  default: ({ left, sections, rightFooter }: any) => (
+    <div data-testid="project-details-layout">
+      <div data-testid="layout-left">{left}</div>
+      <div data-testid="layout-sections">
+        {sections?.map((section: any) => (
+          <div key={section.id} data-testid={`section-${section.id}`}>
+            <span>{section.title}</span>
+            <div>{section.content}</div>
+          </div>
+        ))}
+      </div>
+      <div data-testid="layout-footer">{rightFooter}</div>
+    </div>
+  ),
+}));
+
+jest.mock("@/components/ui/alert-dialog", () => ({
+  AlertDialog: ({ children, open }: any) => (open ? <div>{children}</div> : null),
+  AlertDialogAction: ({ children, onClick }: any) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+  AlertDialogCancel: ({ children }: any) => <button type="button">{children}</button>,
+  AlertDialogContent: ({ children }: any) => <div>{children}</div>,
+  AlertDialogDescription: ({ children }: any) => <div>{children}</div>,
+  AlertDialogFooter: ({ children }: any) => <div>{children}</div>,
+  AlertDialogHeader: ({ children }: any) => <div>{children}</div>,
+  AlertDialogTitle: ({ children }: any) => <div>{children}</div>,
+}));
+
+const mockUseToast = useToast as jest.Mock;
+const mockUseMessagesTranslation = useMessagesTranslation as jest.Mock;
+const mockUseCommonTranslation = useCommonTranslation as jest.Mock;
+const mockUseFormsTranslation = useFormsTranslation as jest.Mock;
+const mockUseSessionActions = useSessionActions as jest.Mock;
+
+const mockToast = jest.fn();
+const mockDeleteSession = jest.fn();
+
+const buildQueryMock = (singleResponse: any) => {
+  const query: any = {};
+  query.select = jest.fn(() => query);
+  query.eq = jest.fn(() => query);
+  query.single = jest.fn().mockResolvedValue(singleResponse);
+  return query;
+};
+
+describe("SessionDetail", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLocationState = {};
+    mockNavigate.mockReset();
+    (mockSupabaseClient.from as jest.Mock).mockReset();
+    mockToast.mockReset();
+    mockDeleteSession.mockReset();
+    mockUseToast.mockReturnValue({ toast: mockToast });
+    mockUseMessagesTranslation.mockReturnValue({
+      t: (key: string) => `messages.${key}`,
+    });
+    mockUseCommonTranslation.mockReturnValue({
+      t: (key: string) => `common.${key}`,
+    });
+    mockUseFormsTranslation.mockReturnValue({
+      t: (key: string) => `forms.${key}`,
+    });
+    mockUseSessionActions.mockReturnValue({
+      deleteSession: mockDeleteSession,
+    });
+  });
+
+  const mockSessionData = {
+    id: "session-123",
+    session_name: "Strategy Session",
+    session_date: "2024-05-01",
+    session_time: "10:00",
+    notes: "Discuss project details",
+    location: "Studio",
+    status: "planned",
+    lead_id: "lead-1",
+    project_id: "project-1",
+    user_id: "user-1",
+    leads: {
+      id: "lead-1",
+      name: "Taylor Swift",
+      email: "taylor@example.com",
+      phone: "+123456789",
+      notes: "VIP",
+    },
+    projects: {
+      id: "project-1",
+      name: "Launch",
+      project_types: {
+        name: "Portrait",
+      },
+    },
+  };
+
+  it("shows loading skeleton before rendering fetched session details", async () => {
+    const query = buildQueryMock({ data: mockSessionData, error: null });
+    (mockSupabaseClient.from as jest.Mock).mockImplementation(() => query);
+
+    const { container } = render(<SessionDetail />);
+
+    expect(
+      container.querySelectorAll('[class*=\"animate-pulse\"]').length
+    ).toBeGreaterThan(0);
+
+    const statusBadge = await screen.findByTestId("session-status-badge");
+
+    expect(query.select).toHaveBeenCalled();
+    expect(query.eq).toHaveBeenCalledWith("id", "session-123");
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('[class*=\"animate-pulse\"]').length).toBe(0);
+    });
+
+    expect(screen.getByTestId("entity-header")).toBeInTheDocument();
+    expect(statusBadge).toHaveAttribute(
+      "aria-label",
+      "status-planned"
+    );
+    expect(screen.getByTestId("unified-client-details")).toHaveTextContent(
+      "lead-Taylor Swift"
+    );
+    expect(screen.getByTestId("session-gallery")).toHaveTextContent(
+      "gallery-session-123"
+    );
+    expect(screen.getByTestId("layout-footer")).toHaveTextContent(
+      "pages.sessionDetail.dangerZone.button"
+    );
+  });
+
+  it("surfaces a toast and empty state when the session fetch fails", async () => {
+    const query = buildQueryMock({
+      data: null,
+      error: new Error("Failed to load"),
+    });
+    (mockSupabaseClient.from as jest.Mock).mockImplementation(() => query);
+
+    render(<SessionDetail />);
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "common.toast.error",
+          description: "pages.sessionDetail.toast.loadErrorDescription",
+          variant: "destructive",
+        })
+      );
+    });
+
+    expect(
+      screen.getByText("pages.sessionDetail.emptyState.title")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("pages.sessionDetail.emptyState.description")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "pages.sessionDetail.emptyState.cta",
+      })
+    ).toBeInTheDocument();
+  });
+
+  it("confirms deletion and navigates using the fallback route when the delete succeeds", async () => {
+    mockLocationState = { from: "/calendar" };
+    mockDeleteSession.mockResolvedValueOnce(true);
+    const query = buildQueryMock({ data: mockSessionData, error: null });
+    (mockSupabaseClient.from as jest.Mock).mockImplementation(() => query);
+
+    render(<SessionDetail />);
+
+    const openDeleteButton = await screen.findByRole("button", {
+      name: "pages.sessionDetail.dangerZone.button",
+    });
+    fireEvent.click(openDeleteButton);
+
+    const confirmButton = await screen.findAllByRole("button", {
+      name: "pages.sessionDetail.dangerZone.button",
+    });
+    fireEvent.click(confirmButton[confirmButton.length - 1]);
+
+    await waitFor(() => {
+      expect(mockDeleteSession).toHaveBeenCalledWith("session-123");
+    });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/calendar");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest coverage for the SessionDetail page covering load success, error handling, and delete navigation
- update the unit-testing plan snapshot, status table, and iteration log for the new coverage

## Testing
- npm test -- --runTestsByPath src/pages/__tests__/SessionDetail.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68fcdd6b15f88321ac7da7ab31f07c06