### PR TITLE
Add unit tests for data table primitives and update testing tracker

### DIFF
--- a/docs/unit-testing-plan.md
+++ b/docs/unit-testing-plan.md
@@ -40,9 +40,9 @@
 | Services & Data Access | 5 | 5 | 100% |
 | Contexts & Hooks | 24 | 24 | 100% |
 | UI Components & Pages | 41 | 44 | 93% |
-| UI Primitives & Shared Components | 13 | 13 | 100% |
+| UI Primitives & Shared Components | 17 | 17 | 100% |
 | Supabase Edge Functions & Automation | 9 | 9 | 100% |
-| **Overall** | **105** | **108** | **97%** |
+| **Overall** | **109** | **112** | **97%** |
 
 ### Core Libraries & Helpers
 | Area | File(s) | What to Cover | Priority | Status | Notes |
@@ -149,14 +149,14 @@
 | Area | File(s) | What to Cover | Priority | Status | Notes |
 | --- | --- | --- | --- | --- | --- |
 | Sheet modal wrapper | `src/components/ui/app-sheet-modal.tsx` | Mobile vs desktop render paths, aria attributes | Medium | Done | Covered by `src/components/ui/__tests__/app-sheet-modal.test.tsx` asserting desktop vs mobile variants, dirty close behavior, and footer action callbacks. |
-| Data table core | `src/components/ui/data-table.tsx` | Column sorting, selection state, virtualization slots | High | Not started | Use Testing Library + fake data to confirm interactions. |
-| Data table container | `src/components/ui/data-table-container.tsx` | Responsive layout, toolbar slots, sticky headers | Medium | Not started | Snapshot narrow vs wide viewports. |
-| Date/time picker | `src/components/ui/date-time-picker.tsx` | Timezone defaults, validation boundaries | Medium | Not started | Mock date to ensure min/max enforcement. |
+| Data table core | `src/components/ui/data-table.tsx` | Column sorting, selection state, virtualization slots | High | Done | Covered by `src/components/ui/__tests__/data-table.test.tsx` validating pagination, sorting toggles, empty state, and row clicks. |
+| Data table container | `src/components/ui/data-table-container.tsx` | Responsive layout, toolbar slots, sticky headers | Medium | Done | Covered by `src/components/ui/__tests__/data-table-container.test.tsx` asserting base wrapper classes and inner width guards. |
+| Date/time picker | `src/components/ui/date-time-picker.tsx` | Timezone defaults, validation boundaries | Medium | Done | Covered by `src/components/ui/__tests__/date-time-picker.test.tsx` for formatted labels, date selection, time adjustments, and clearing. |
 | KPI presets | `src/components/ui/kpi-presets.ts` | Metric formatting, threshold coloring | Low | Done | Covered by `src/components/ui/__tests__/kpi-presets.test.ts` (base classes + overrides). |
 | Loading presets | `src/components/ui/loading-presets.tsx` | Skeleton variants, accessibility roles | Low | Done | Covered by `src/components/ui/__tests__/loading-presets.test.tsx` validating wrapper classes and variant props. |
 | Long press confirmation button | `src/components/ui/long-press-button.tsx` | Hold lifecycle, countdown feedback, completion reset | Medium | Done | Covered by `src/components/ui/__tests__/long-press-button.test.tsx` asserting hold/confirm interactions and post-confirm reset. |
 | Toast hook | `src/components/ui/use-toast.ts` | Queue handling, duplicate suppression, dismissal timers | Medium | Done | Covered by `src/components/ui/__tests__/use-toast.test.ts` using fake timers for queue limits, updates, and dismiss removal. |
-| Toast renderer | `src/components/ui/toaster.tsx` | Mount/unmount behavior, focus management | Medium | Not started | Ensure toasts remain accessible via keyboard navigation. |
+| Toast renderer | `src/components/ui/toaster.tsx` | Mount/unmount behavior, focus management | Medium | Done | Covered by `src/components/ui/__tests__/toaster.test.tsx` ensuring toast rendering and viewport accessibility. |
 | Segmented control | `src/components/ui/segmented-control.tsx` | Value switching, disabled tooltips, indicator alignment | Medium | Done | Covered by `src/components/ui/__tests__/segmented-control.test.tsx` validating selection state, disabled guard, and tooltip content. |
 | Page header layout | `src/components/ui/page-header.tsx` | Sticky wrapper, responsive slots, action grouping | Low | Done | Covered by `src/components/ui/__tests__/page-header.test.tsx` confirming sticky classes and slot layout wrappers. |
 | Pagination primitives | `src/components/ui/pagination.tsx` | i18n labels, aria-current handling, ellipsis semantics | Low | Done | Covered by `src/components/ui/__tests__/pagination.test.tsx` checking navigation labeling, active link, and ellipsis sr-only text. |

--- a/src/components/ui/__tests__/data-table-container.test.tsx
+++ b/src/components/ui/__tests__/data-table-container.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@/utils/testUtils";
+import { DataTableContainer } from "../data-table-container";
+
+describe("DataTableContainer", () => {
+  it("applies base styling and renders children", () => {
+    render(
+      <DataTableContainer className="custom-wrapper">
+        <div data-testid="inner">content</div>
+      </DataTableContainer>
+    );
+
+    const inner = screen.getByTestId("inner").parentElement as HTMLElement;
+    const outer = inner.parentElement as HTMLElement;
+
+    expect(outer.className).toContain("data-table-container");
+    expect(outer.className).toContain("w-full");
+    expect(outer.className).toContain("custom-wrapper");
+
+    expect(inner.className).toContain("min-w-full");
+    expect(inner.className).toContain("md:min-w-max");
+  });
+});

--- a/src/components/ui/__tests__/data-table.test.tsx
+++ b/src/components/ui/__tests__/data-table.test.tsx
@@ -1,0 +1,108 @@
+import { fireEvent, render, screen } from "@/utils/testUtils";
+import { DataTable } from "../data-table";
+import { useTranslation } from "react-i18next";
+
+type Person = { name: string };
+
+jest.mock("react-i18next", () => ({
+  useTranslation: jest.fn(),
+}));
+
+describe("DataTable", () => {
+  const renderTable = (override?: Partial<Parameters<typeof DataTable>[0]>) => {
+    const columns = [
+      {
+        key: "name",
+        header: "Name",
+        sortable: true,
+      },
+    ];
+
+    const data: Person[] = [
+      { name: "Zed" },
+      { name: "Ada" },
+      { name: "Mike" },
+    ];
+
+    return render(
+      <DataTable<Person>
+        data={data}
+        columns={columns}
+        itemsPerPage={2}
+        {...override}
+      />
+    );
+  };
+
+  beforeEach(() => {
+    (useTranslation as jest.Mock).mockReturnValue({
+      t: (key: string, options?: Record<string, number>) => {
+        if (key === "labels.showing_results" && options) {
+          return `Showing ${options.start}-${options.end} of ${options.total}`;
+        }
+        if (key === "table.noDataAvailable") {
+          return "No data available";
+        }
+        if (key === "buttons.previous") {
+          return "Previous";
+        }
+        if (key === "buttons.next") {
+          return "Next";
+        }
+        return key;
+      },
+    });
+  });
+
+  it("renders rows and updates pagination info when changing pages", () => {
+    renderTable();
+
+    expect(screen.getByText("Showing 1-2 of 3")).toBeInTheDocument();
+
+    let bodyCells = screen.getAllByRole("cell");
+    expect(bodyCells[0]).toHaveTextContent("Zed");
+    expect(bodyCells[1]).toHaveTextContent("Ada");
+
+    const pageTwo = screen.getByText("2");
+    fireEvent.click(pageTwo.closest("a") ?? pageTwo);
+
+    expect(screen.getByText("Showing 3-3 of 3")).toBeInTheDocument();
+
+    bodyCells = screen.getAllByRole("cell");
+    expect(bodyCells).toHaveLength(1);
+    expect(bodyCells[0]).toHaveTextContent("Mike");
+  });
+
+  it("supports sorting toggles for sortable columns", () => {
+    renderTable();
+
+    const header = screen.getByRole("columnheader", { name: /Name/ });
+
+    fireEvent.click(header);
+
+    let bodyCells = screen.getAllByRole("cell");
+    expect(bodyCells[0]).toHaveTextContent("Ada");
+    expect(bodyCells[1]).toHaveTextContent("Mike");
+
+    fireEvent.click(header);
+    bodyCells = screen.getAllByRole("cell");
+    expect(bodyCells[0]).toHaveTextContent("Zed");
+    expect(bodyCells[1]).toHaveTextContent("Mike");
+  });
+
+  it("renders default empty state when no data is provided", () => {
+    renderTable({ data: [] });
+
+    expect(screen.queryByRole("cell", { name: "-" })).not.toBeInTheDocument();
+    expect(screen.getByText("No data available")).toBeInTheDocument();
+  });
+
+  it("fires row click callback when provided", () => {
+    const onRowClick = jest.fn();
+    renderTable({ onRowClick });
+
+    fireEvent.click(screen.getAllByRole("row")[1]);
+
+    expect(onRowClick).toHaveBeenCalledWith({ name: "Zed" });
+  });
+});

--- a/src/components/ui/__tests__/date-time-picker.test.tsx
+++ b/src/components/ui/__tests__/date-time-picker.test.tsx
@@ -1,0 +1,123 @@
+import { fireEvent, render, screen } from "@/utils/testUtils";
+import { format } from "date-fns";
+import { getDateFnsLocale } from "@/lib/utils";
+import { DateTimePicker } from "../date-time-picker";
+
+jest.mock("react-calendar/dist/Calendar.css", () => ({}), { virtual: true });
+jest.mock("@/components/react-calendar.css", () => ({}), { virtual: true });
+
+jest.mock("@/components/ui/popover", () => {
+  const React = require("react");
+  return {
+    Popover: ({ children }: any) => <div data-testid="popover">{children}</div>,
+    PopoverTrigger: ({ children }: any) => <div>{children}</div>,
+    PopoverContent: ({ children }: any) => <div>{children}</div>,
+  };
+});
+
+jest.mock("@/components/ui/select", () => {
+  const React = require("react");
+
+  const SelectValue = ({ placeholder }: any) => (
+    <option value="">{placeholder}</option>
+  );
+
+  const SelectItem = ({ value, children }: any) => (
+    <option value={value}>{children}</option>
+  );
+
+  const collectOptions = (nodes: any): any[] => {
+    const options: any[] = [];
+    React.Children.forEach(nodes, (child: any) => {
+      if (!React.isValidElement(child)) return;
+      if (child.type === SelectValue || child.type === SelectItem) {
+        options.push(child);
+        return;
+      }
+      if (child.props?.children) {
+        options.push(...collectOptions(child.props.children));
+      }
+    });
+    return options;
+  };
+
+  const Select = ({ children, value, onValueChange, className, ...rest }: any) => {
+    const options = collectOptions(children);
+    return (
+      <select
+        className={className}
+        data-testid={rest["data-testid"]}
+        value={value}
+        onChange={event => onValueChange?.(event.target.value)}
+      >
+        {options}
+      </select>
+    );
+  };
+
+  const SelectTrigger = ({ children }: any) => <>{children}</>;
+  const SelectContent = ({ children }: any) => <>{children}</>;
+
+  return { Select, SelectTrigger, SelectValue, SelectContent, SelectItem };
+});
+
+jest.mock("react-calendar", () => ({
+  __esModule: true,
+  default: ({ onChange }: any) => (
+    <div>
+      <button type="button" onClick={() => onChange(new Date(2024, 0, 15))}>
+        choose-date
+      </button>
+    </div>
+  ),
+}));
+
+describe("DateTimePicker", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows placeholder text when no value is provided", () => {
+    render(<DateTimePicker onChange={jest.fn()} />);
+
+    expect(
+      screen.getByRole("button", { name: /Pick date & time/i })
+    ).toBeInTheDocument();
+  });
+
+  it("renders the formatted value when an initial date is provided", () => {
+    const value = "2024-01-05T10:30";
+    render(<DateTimePicker value={value} onChange={jest.fn()} />);
+
+    const button = screen.getByRole("button", { name: /2024/ });
+    const expected = format(new Date("2024-01-05T10:30"), "PP p", {
+      locale: getDateFnsLocale(),
+    });
+    expect(button).toHaveTextContent(expected);
+  });
+
+  it("emits ISO local strings when selecting a date and adjusting the time", () => {
+    const onChange = jest.fn();
+    render(<DateTimePicker onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "choose-date" }));
+    expect(onChange).toHaveBeenLastCalledWith("2024-01-15T09:00");
+
+    const [hoursSelect, minutesSelect] = screen.getAllByRole("combobox");
+
+    fireEvent.change(hoursSelect, { target: { value: "15" } });
+    expect(onChange).toHaveBeenLastCalledWith("2024-01-15T15:00");
+
+    fireEvent.change(minutesSelect, { target: { value: "30" } });
+    expect(onChange).toHaveBeenLastCalledWith("2024-01-15T15:30");
+  });
+
+  it("clears the current selection via the clear button", () => {
+    const onChange = jest.fn();
+    render(<DateTimePicker onChange={onChange} value="2024-02-10T12:00" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+    expect(onChange).toHaveBeenLastCalledWith("");
+    expect(screen.getByRole("button", { name: /Pick date & time/ })).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/__tests__/toaster.test.tsx
+++ b/src/components/ui/__tests__/toaster.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@/utils/testUtils";
+import { Toaster } from "../toaster";
+import { useToast } from "@/hooks/use-toast";
+
+jest.mock("@/hooks/use-toast", () => ({
+  useToast: jest.fn(),
+}));
+
+describe("Toaster", () => {
+  beforeEach(() => {
+    (useToast as jest.Mock).mockReturnValue({
+      toasts: [],
+    });
+  });
+
+  it("renders toast items with their titles, descriptions, and actions", () => {
+    (useToast as jest.Mock).mockReturnValue({
+      toasts: [
+        {
+          id: "1",
+          title: "Update ready",
+          description: "Install the latest build",
+          action: <button type="button">Retry</button>,
+        },
+        {
+          id: "2",
+          description: "Background sync complete",
+        },
+      ],
+    });
+
+    const { container } = render(<Toaster />);
+
+    expect(screen.getByText("Update ready")).toBeInTheDocument();
+    expect(screen.getByText("Install the latest build")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+    expect(screen.getByText("Background sync complete")).toBeInTheDocument();
+
+    const closeButtons = container.querySelectorAll('[toast-close]');
+    expect(closeButtons).toHaveLength(2);
+  });
+
+  it("always mounts the toast viewport for accessibility", () => {
+    render(<Toaster />);
+
+    expect(
+      screen.getByRole("region", { name: /notifications/i })
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest coverage for the shared DataTable component, container wrapper, and toaster renderer
- add focused tests for the date-time picker interactions
- refresh the unit testing plan snapshot and mark the newly covered primitives as done

## Testing
- npm test -- --runTestsByPath src/components/ui/__tests__/data-table.test.tsx src/components/ui/__tests__/data-table-container.test.tsx src/components/ui/__tests__/date-time-picker.test.tsx src/components/ui/__tests__/toaster.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68fce6e44074832192ce35925b71bd78