### PR TITLE
Add activity timeline unit tests

### DIFF
--- a/docs/unit-testing-plan.md
+++ b/docs/unit-testing-plan.md
@@ -39,10 +39,10 @@
 | Core Libraries & Helpers | 13 | 13 | 100% |
 | Services & Data Access | 5 | 5 | 100% |
 | Contexts & Hooks | 24 | 24 | 100% |
-| UI Components & Pages | 42 | 44 | 95% |
+| UI Components & Pages | 44 | 44 | 100% |
 | UI Primitives & Shared Components | 17 | 17 | 100% |
 | Supabase Edge Functions & Automation | 9 | 9 | 100% |
-| **Overall** | **110** | **112** | **98%** |
+| **Overall** | **112** | **112** | **100%** |
 
 ### Core Libraries & Helpers
 | Area | File(s) | What to Cover | Priority | Status | Notes |
@@ -132,8 +132,8 @@
 | Unified client details | `src/components/UnifiedClientDetails.tsx` | Conditional rendering of contact info, copy buttons | Low | Done | Covered by `src/components/__tests__/UnifiedClientDetails.test.tsx` validating quick actions, custom field display, navigation hooks, and validation toasts. |
 | Project sheet view | `src/components/ProjectSheetView.tsx` | Printable layout, localization of labels, totals | Medium | Done | Covered by `src/components/__tests__/ProjectSheetView.test.tsx` validating supabase fetch stubs, edit/save flow, and archive confirmation handling. |
 | Onboarding modal | `src/components/OnboardingModal.tsx` | Step transitions, skip behavior, analytics events | Medium | Done | Covered by `src/components/__tests__/OnboardingModal.test.tsx` validating guided setup launch, navigation, and sample data modal toggle. |
-| Activity timeline section | `src/components/ActivitySection.tsx` | Activity CRUD, reminder scheduling, filter tabs | High | Not started | Stub Supabase helpers to ensure create/edit validation, filter chips, and audit log rendering with skeleton states. |
-| Lead activity section | `src/components/LeadActivitySection.tsx` | Segmented activity/history views, cross-entity fetches, audit timeline | Medium | Not started | Mock Supabase responses to assert segment toggles, merged histories, and toast errors. |
+| Activity timeline section | `src/components/ActivitySection.tsx` | Activity CRUD, reminder scheduling, filter tabs | High | Done | Covered by `src/components/__tests__/ActivitySection.test.tsx` verifying filter pills, Supabase-driven creation flow, and toast feedback. |
+| Lead activity section | `src/components/LeadActivitySection.tsx` | Segmented activity/history views, cross-entity fetches, audit timeline | Medium | Done | Covered by `src/components/__tests__/LeadActivitySection.test.tsx` exercising segment toggles, activity creation, and completion toasts with mocked Supabase chains. |
 | Workflow creation sheet | `src/components/CreateWorkflowSheet.tsx` | Form dirty-state guard, channel toggles, template selection, create/update branching | High | Done | Covered by `src/components/__tests__/CreateWorkflowSheet.test.tsx` for edit prefill, update submission payloads, and empty-template messaging. |
 | Workflow delete dialog | `src/components/WorkflowDeleteDialog.tsx` | Confirmation copy, destructive action wiring, disabled state | Medium | Done | Covered by `src/components/__tests__/WorkflowDeleteDialog.test.tsx` verifying translation text, cancel/confirm callbacks, close handling, and disabled deletion state. |
 | Project sheet preview | `src/components/ProjectSheetPreview.tsx` | Modal lifecycle, related data fetches, navigation callbacks | Medium | Done | Covered by `src/components/__tests__/ProjectSheetPreview.test.tsx` ensuring Supabase fetch stubs hydrate metrics, navigation closes modal, and status change triggers updates. |
@@ -265,6 +265,7 @@ _Statuses_: `Not started`, `In progress`, `Blocked`, `Ready for review`, `Done`.
 | 2025-11-03 (later) | Codex | Added Templates workspace coverage | `src/pages/__tests__/Templates.test.tsx` locks preview translation fallback, search empty states, duplication/deletion flows, and navigation callbacks | Next: Cover Project sheet view snapshot translations |
 | 2025-11-04 | Codex | Added onboarding modal, workflow sheet, and project preview coverage | Added `src/components/__tests__/OnboardingModal.test.tsx`, `CreateWorkflowSheet.test.tsx`, and `ProjectSheetPreview.test.tsx` to validate modal flows, edit submission payloads, and Supabase-driven previews | Next: Target ProjectSheetView, ActivitySection, and LeadActivitySection components |
 | 2025-11-05 | Codex | Added Project sheet view coverage | `src/components/__tests__/ProjectSheetView.test.tsx` covers data hydration, edit/save flow, and archive confirmation logic with mocked Supabase + toast hooks | Next: Continue with ActivitySection and LeadActivitySection coverage |
+| 2025-11-05 (later) | Codex | Added activity timelines for leads/projects | Added `src/components/__tests__/ActivitySection.test.tsx` and `LeadActivitySection.test.tsx` to validate filter modes, creation toasts, history segments, and completion toggles | Monitor for new activity types or audit entities to extend fixtures |
 
 ## Maintenance Rules of Thumb
 - Treat this file like the single source of truth for unit testing status—update it in the same PR as any test additions or strategy changes.

--- a/src/components/__tests__/ActivitySection.test.tsx
+++ b/src/components/__tests__/ActivitySection.test.tsx
@@ -1,0 +1,281 @@
+import { fireEvent, render, screen, waitFor } from "@/utils/testUtils";
+import ActivitySection from "../ActivitySection";
+import { supabase } from "@/integrations/supabase/client";
+import { getUserOrganizationId } from "@/lib/organizationUtils";
+import { useFormsTranslation, useCommonTranslation } from "@/hooks/useTypedTranslation";
+
+jest.mock("@/hooks/use-toast", () => {
+  const toastSpy = jest.fn();
+  const useToastMock = jest.fn(() => ({ toast: toastSpy }));
+  return {
+    __esModule: true,
+    useToast: useToastMock,
+    toast: jest.fn(),
+    __toastSpy: toastSpy,
+    __useToastMock: useToastMock,
+  };
+});
+
+const { __toastSpy, __useToastMock } = jest.requireMock("@/hooks/use-toast");
+const toastSpy = __toastSpy as jest.Mock;
+const useToastMock = __useToastMock as jest.Mock;
+
+jest.mock("@/hooks/useTypedTranslation", () => ({
+  useFormsTranslation: jest.fn(),
+  useCommonTranslation: jest.fn(),
+}));
+
+jest.mock("@/lib/organizationUtils", () => ({
+  getUserOrganizationId: jest.fn(),
+}));
+
+jest.mock("@/components/ui/select", () => {
+  const React = require("react");
+  const SelectContext = React.createContext<{ onValueChange: (value: string) => void }>({
+    onValueChange: () => {},
+  });
+
+  return {
+    __esModule: true,
+    Select: ({ onValueChange, children }: any) => (
+      <SelectContext.Provider value={{ onValueChange }}>{children}</SelectContext.Provider>
+    ),
+    SelectTrigger: ({ children }: any) => <button type="button">{children}</button>,
+    SelectContent: ({ children }: any) => <div>{children}</div>,
+    SelectValue: ({ children }: any) => <span>{children}</span>,
+    SelectItem: ({ value, children }: any) => {
+      const ctx = React.useContext(SelectContext);
+      return (
+        <button type="button" onClick={() => ctx.onValueChange(value)}>
+          {children}
+        </button>
+      );
+    },
+  };
+});
+
+jest.mock("@/components/ui/tabs", () => {
+  const React = require("react");
+  const TabsContext = React.createContext<{ value: string; onValueChange: (value: string) => void }>({
+    value: "",
+    onValueChange: () => {},
+  });
+
+  return {
+    __esModule: true,
+    Tabs: ({ value, onValueChange, children }: any) => (
+      <TabsContext.Provider value={{ value, onValueChange }}>{children}</TabsContext.Provider>
+    ),
+    TabsList: ({ children }: any) => <div>{children}</div>,
+    TabsTrigger: ({ value, children }: any) => {
+      const ctx = React.useContext(TabsContext);
+      const isActive = ctx.value === value;
+      return (
+        <button type="button" aria-pressed={isActive} onClick={() => ctx.onValueChange(value)}>
+          {children}
+        </button>
+      );
+    },
+    TabsContent: ({ value, children }: any) => {
+      const ctx = React.useContext(TabsContext);
+      return ctx.value === value ? <div>{children}</div> : null;
+    },
+  };
+});
+
+jest.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    from: jest.fn(),
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+describe("ActivitySection", () => {
+  const mockUseFormsTranslation = useFormsTranslation as jest.Mock;
+  const mockUseCommonTranslation = useCommonTranslation as jest.Mock;
+  const mockGetUserOrganizationId = getUserOrganizationId as jest.Mock;
+  const supabaseFromMock = supabase.from as jest.Mock;
+  const supabaseAuthGetUserMock = supabase.auth.getUser as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    toastSpy.mockReset();
+
+    mockUseFormsTranslation.mockReturnValue({
+      t: (key: string) => key,
+    });
+    mockUseCommonTranslation.mockReturnValue({
+      t: (key: string) => key,
+    });
+    mockGetUserOrganizationId.mockResolvedValue("org-123");
+    supabaseAuthGetUserMock.mockResolvedValue({ data: { user: { id: "user-1" } }, error: null });
+  });
+
+  const setupSupabase = () => {
+    const activities = [
+      {
+        id: "activity-1",
+        type: "note",
+        content: "Initial follow-up",
+        reminder_date: null,
+        reminder_time: null,
+        organization_id: "org-123",
+        user_id: "user-1",
+        lead_id: "lead-1",
+        project_id: null,
+        completed: false,
+        created_at: "2025-02-01T10:00:00.000Z",
+        updated_at: "2025-02-01T10:00:00.000Z",
+      },
+      {
+        id: "activity-2",
+        type: "call",
+        content: "Completed call",
+        reminder_date: null,
+        reminder_time: null,
+        organization_id: "org-123",
+        user_id: "user-1",
+        lead_id: "lead-1",
+        project_id: null,
+        completed: true,
+        created_at: "2025-02-02T12:00:00.000Z",
+        updated_at: "2025-02-02T12:00:00.000Z",
+      },
+    ];
+
+    const sessions = [
+      {
+        id: "session-1",
+        session_name: "Strategy Session",
+        session_date: "2025-02-05",
+        session_time: "10:00",
+        location: "Studio",
+        notes: "Discuss next steps",
+        status: "scheduled",
+        created_at: "2025-02-03T09:00:00.000Z",
+        updated_at: "2025-02-03T09:00:00.000Z",
+      },
+    ];
+
+    const activitiesSelectMock = jest.fn(() => ({
+      eq: jest.fn(() => ({
+        order: jest.fn(() => Promise.resolve({ data: activities, error: null })),
+      })),
+    }));
+
+    const sessionsSelectMock = jest.fn(() => ({
+      eq: jest.fn(() => ({
+        order: jest.fn(() => Promise.resolve({ data: sessions, error: null })),
+      })),
+    }));
+
+    const auditSelectMock = jest.fn(() => ({
+      eq: jest.fn(() => ({
+        order: jest.fn(() => ({
+          limit: jest.fn(() => Promise.resolve({ data: [], error: null })),
+        })),
+      })),
+    }));
+
+    const profilesSelectMock = jest.fn(() => ({
+      in: jest.fn(() => Promise.resolve({ data: [], error: null })),
+    }));
+
+    const insertMock = jest.fn(() => Promise.resolve({ error: null }));
+    const updateEqMock = jest.fn(() => Promise.resolve({ error: null }));
+    const updateMock = jest.fn(() => ({ eq: updateEqMock }));
+    const deleteEqMock = jest.fn(() => Promise.resolve({ error: null }));
+    const deleteMock = jest.fn(() => ({ eq: deleteEqMock }));
+
+    supabaseFromMock.mockImplementation((table: string) => {
+      if (table === "activities") {
+        return {
+          select: activitiesSelectMock,
+          insert: insertMock,
+          update: updateMock,
+          delete: deleteMock,
+        };
+      }
+      if (table === "sessions") {
+        return {
+          select: sessionsSelectMock,
+        };
+      }
+      if (table === "audit_log") {
+        return {
+          select: auditSelectMock,
+        };
+      }
+      if (table === "profiles") {
+        return {
+          select: profilesSelectMock,
+        };
+      }
+      return {};
+    });
+
+    return { activitiesSelectMock, insertMock };
+  };
+
+  it("renders fetched activities and filters completed items", async () => {
+    const { activitiesSelectMock } = setupSupabase();
+
+    render(<ActivitySection entityType="lead" entityId="lead-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Initial follow-up")).toBeInTheDocument();
+      expect(screen.getByText("Completed call")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Strategy Session")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("activities.filter_completed"));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Initial follow-up")).not.toBeInTheDocument();
+    });
+    expect(screen.getByText("Completed call")).toBeInTheDocument();
+
+    expect(activitiesSelectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("creates a new activity and refreshes the list", async () => {
+    const { activitiesSelectMock, insertMock } = setupSupabase();
+    const onUpdate = jest.fn();
+
+    render(<ActivitySection entityType="lead" entityId="lead-1" onUpdate={onUpdate} />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("placeholders.enter_activity_content")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByPlaceholderText("placeholders.enter_activity_content"), {
+      target: { value: "New activity" },
+    });
+
+    fireEvent.click(screen.getByText("activities.add_activity"));
+
+    await waitFor(() => {
+      expect(insertMock).toHaveBeenCalledWith(expect.objectContaining({
+        type: "note",
+        content: "New activity",
+        lead_id: "lead-1",
+        organization_id: "org-123",
+        user_id: "user-1",
+      }));
+    });
+
+    expect(toastSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "actions.success",
+        description: "messages.success.save",
+      })
+    );
+
+    expect(activitiesSelectMock).toHaveBeenCalledTimes(2);
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    expect(screen.getByPlaceholderText("placeholders.enter_activity_content")).toHaveValue("");
+  });
+});

--- a/src/components/__tests__/LeadActivitySection.test.tsx
+++ b/src/components/__tests__/LeadActivitySection.test.tsx
@@ -1,0 +1,331 @@
+import { fireEvent, render, screen, waitFor } from "@/utils/testUtils";
+import { LeadActivitySection } from "../LeadActivitySection";
+import { supabase } from "@/integrations/supabase/client";
+import { getUserOrganizationId } from "@/lib/organizationUtils";
+import { useFormsTranslation } from "@/hooks/useTypedTranslation";
+import { toast } from "@/hooks/use-toast";
+
+jest.mock("@/hooks/use-toast", () => ({
+  useToast: jest.fn(() => ({ toast: jest.fn() })),
+  toast: jest.fn(),
+}));
+
+jest.mock("@/hooks/useTypedTranslation", () => ({
+  useFormsTranslation: jest.fn(),
+}));
+
+jest.mock("@/lib/organizationUtils", () => ({
+  getUserOrganizationId: jest.fn(),
+}));
+
+jest.mock("@/components/shared/ActivityForm", () => ({
+  ActivityForm: ({ onSubmit }: any) => (
+    <div>
+      <button type="button" data-testid="submit-activity" onClick={() => onSubmit("Mock activity", false)}>
+        submit-activity
+      </button>
+    </div>
+  ),
+}));
+
+jest.mock("@/components/shared/ActivityTimeline", () => ({
+  ActivityTimeline: ({ activities, onToggleCompletion }: any) => (
+    <div>
+      {activities.map((activity: any) => (
+        <div key={activity.id}>
+          <span>{activity.content}</span>
+          {onToggleCompletion && (
+            <button
+              type="button"
+              data-testid={`toggle-activity-${activity.id}`}
+              onClick={() => onToggleCompletion(activity.id, !activity.completed)}
+            >
+              toggle
+            </button>
+          )}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+jest.mock("@/components/ui/segmented-control", () => ({
+  SegmentedControl: ({ value, onValueChange, options }: any) => (
+    <div>
+      {options.map((option: any) => (
+        <button
+          key={option.value}
+          type="button"
+          data-testid={`segment-${option.value}`}
+          onClick={() => onValueChange(option.value)}
+        >
+          {option.label}
+        </button>
+      ))}
+      <span data-testid="current-segment">{value}</span>
+    </div>
+  ),
+}));
+
+jest.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    from: jest.fn(),
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+describe("LeadActivitySection", () => {
+  const mockUseFormsTranslation = useFormsTranslation as jest.Mock;
+  const mockGetUserOrganizationId = getUserOrganizationId as jest.Mock;
+  const supabaseFromMock = supabase.from as jest.Mock;
+  const supabaseAuthGetUserMock = supabase.auth.getUser as jest.Mock;
+  const toastMock = toast as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    toastMock.mockReset();
+
+    mockUseFormsTranslation.mockReturnValue({
+      t: (key: string) => key,
+    });
+    mockGetUserOrganizationId.mockResolvedValue("org-123");
+    supabaseAuthGetUserMock.mockResolvedValue({ data: { user: { id: "user-1" } }, error: null });
+  });
+
+  const setupSupabase = () => {
+    const leadActivities = [
+      {
+        id: "lead-activity-1",
+        type: "note",
+        content: "Lead note",
+        reminder_date: null,
+        reminder_time: null,
+        created_at: "2025-02-01T10:00:00.000Z",
+        completed: false,
+        lead_id: "lead-1",
+        user_id: "user-1",
+      },
+    ];
+
+    const projectActivities = [
+      {
+        id: "project-activity-1",
+        type: "reminder",
+        content: "Project reminder",
+        reminder_date: "2025-02-05",
+        reminder_time: "09:00",
+        created_at: "2025-02-01T10:00:00.000Z",
+        completed: true,
+        lead_id: "lead-1",
+        user_id: "user-1",
+        project_id: "project-1",
+      },
+    ];
+
+    const projects = [{ id: "project-1", name: "Project A" }];
+    const projectIds = [{ id: "project-1" }];
+    const sessions = [{ id: "session-1" }];
+
+    const leadAuditLogs = [
+      {
+        id: "audit-1",
+        user_id: "user-1",
+        entity_type: "lead",
+        entity_id: "lead-1",
+        action: "created",
+        created_at: "2025-02-01T10:00:00.000Z",
+      },
+    ];
+
+    const projectAuditLogs = [
+      {
+        id: "audit-2",
+        user_id: "user-1",
+        entity_type: "project",
+        entity_id: "project-1",
+        action: "created",
+        new_values: { name: "Project A" },
+        created_at: "2025-02-02T10:00:00.000Z",
+      },
+    ];
+
+    const sessionAuditLogs = [
+      {
+        id: "audit-3",
+        user_id: "user-1",
+        entity_type: "session",
+        entity_id: "session-1",
+        action: "created",
+        new_values: { session_name: "Kickoff" },
+        created_at: "2025-02-03T10:00:00.000Z",
+      },
+    ];
+
+    let activitiesSelectCall = 0;
+    const activitiesSelectMock = jest.fn(() => {
+      activitiesSelectCall += 1;
+      if (activitiesSelectCall === 1 || activitiesSelectCall >= 3) {
+        return {
+          eq: jest.fn(() => ({
+            is: jest.fn(() => ({
+              order: jest.fn(() => Promise.resolve({ data: leadActivities, error: null })),
+            })),
+          })),
+        };
+      }
+      return {
+        eq: jest.fn(() => ({
+          not: jest.fn(() => ({
+            order: jest.fn(() => Promise.resolve({ data: projectActivities, error: null })),
+          })),
+        })),
+      };
+    });
+
+    const projectsSelectMock = jest.fn((fields: string) => {
+      if (fields.includes("name")) {
+        return {
+          eq: jest.fn(() => Promise.resolve({ data: projects, error: null })),
+        };
+      }
+      return {
+        eq: jest.fn(() => Promise.resolve({ data: projectIds, error: null })),
+      };
+    });
+
+    const sessionsSelectMock = jest.fn(() => ({
+      eq: jest.fn(() => Promise.resolve({ data: sessions, error: null })),
+    }));
+
+    let auditSelectCall = 0;
+    const auditSelectMock = jest.fn(() => {
+      auditSelectCall += 1;
+      if (auditSelectCall === 1) {
+        return {
+          eq: jest.fn(() => ({
+            order: jest.fn(() => Promise.resolve({ data: leadAuditLogs, error: null })),
+          })),
+        };
+      }
+      if (auditSelectCall === 2) {
+        return {
+          in: jest.fn(() => ({
+            order: jest.fn(() => Promise.resolve({ data: projectAuditLogs, error: null })),
+          })),
+        };
+      }
+      return {
+        in: jest.fn(() => ({
+          order: jest.fn(() => Promise.resolve({ data: sessionAuditLogs, error: null })),
+        })),
+      };
+    });
+
+    const insertSingleMock = jest.fn(() => Promise.resolve({ data: { id: "new-activity" }, error: null }));
+    const insertSelectMock = jest.fn(() => ({ single: insertSingleMock }));
+    const insertMock = jest.fn(() => ({ select: insertSelectMock }));
+    const updateEqMock = jest.fn(() => Promise.resolve({ error: null }));
+    const updateMock = jest.fn(() => ({ eq: updateEqMock }));
+
+    supabaseFromMock.mockImplementation((table: string) => {
+      if (table === "activities") {
+        return {
+          select: activitiesSelectMock,
+          insert: insertMock,
+          update: updateMock,
+        };
+      }
+      if (table === "projects") {
+        return {
+          select: projectsSelectMock,
+        };
+      }
+      if (table === "sessions") {
+        return {
+          select: sessionsSelectMock,
+        };
+      }
+      if (table === "audit_log") {
+        return {
+          select: auditSelectMock,
+        };
+      }
+      return {};
+    });
+
+    return {
+      insertMock,
+      insertSelectMock,
+      insertSingleMock,
+      updateMock,
+      updateEqMock,
+      activitiesSelectMock,
+    };
+  };
+
+  it("renders lead and project activities and toggles to history", async () => {
+    setupSupabase();
+
+    render(<LeadActivitySection leadId="lead-1" leadName="Jane Doe" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Lead note")).toBeInTheDocument();
+      expect(screen.getByText("Project reminder")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("segment-history"));
+
+    await waitFor(() => {
+      expect(screen.getByText("activityLogs.lead_created")).toBeInTheDocument();
+      expect(screen.getByText('Project "Project A" created')).toBeInTheDocument();
+      expect(screen.getByText('Session "Kickoff" created')).toBeInTheDocument();
+    });
+  });
+
+  it("submits a new activity and toggles completion", async () => {
+    const { insertMock, updateMock, updateEqMock, activitiesSelectMock } = setupSupabase();
+    const onActivityUpdated = jest.fn();
+
+    render(<LeadActivitySection leadId="lead-1" leadName="Jane Doe" onActivityUpdated={onActivityUpdated} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Lead note")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("submit-activity"));
+
+    await waitFor(() => {
+      expect(insertMock).toHaveBeenCalledWith(expect.objectContaining({
+        user_id: "user-1",
+        lead_id: "lead-1",
+        type: "note",
+        content: "Mock activity",
+        organization_id: "org-123",
+      }));
+    });
+
+    expect(toastMock).toHaveBeenNthCalledWith(1, {
+      title: "Success",
+      description: "Note added successfully.",
+    });
+
+    expect(onActivityUpdated).toHaveBeenCalledTimes(1);
+    expect(activitiesSelectMock).toHaveBeenCalledTimes(3);
+
+    fireEvent.click(screen.getByTestId("toggle-activity-lead-activity-1"));
+
+    await waitFor(() => {
+      expect(updateMock).toHaveBeenCalledWith({ completed: true });
+      expect(updateEqMock).toHaveBeenCalledWith("id", "lead-activity-1");
+    });
+
+    expect(toastMock).toHaveBeenNthCalledWith(2, {
+      title: "Task marked as completed",
+      description: "Task status updated successfully.",
+    });
+
+    expect(onActivityUpdated).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest coverage for ActivitySection filtering and creation flows using mocked Supabase responses
- add LeadActivitySection tests for segment toggles, creation success, and completion updates
- update unit-testing-plan progress snapshot and iteration log to reflect the new coverage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fcf0def2b08321ada8ef786837d5bf