### PR TITLE
Add coverage for settings pages

### DIFF
--- a/docs/unit-testing-plan.md
+++ b/docs/unit-testing-plan.md
@@ -39,10 +39,10 @@
 | Core Libraries & Helpers | 13 | 13 | 100% |
 | Services & Data Access | 5 | 5 | 100% |
 | Contexts & Hooks | 24 | 24 | 100% |
-| UI Components & Pages | 44 | 44 | 100% |
+| UI Components & Pages | 47 | 47 | 100% |
 | UI Primitives & Shared Components | 17 | 17 | 100% |
 | Supabase Edge Functions & Automation | 9 | 9 | 100% |
-| **Overall** | **112** | **112** | **100%** |
+| **Overall** | **115** | **115** | **100%** |
 
 ### Core Libraries & Helpers
 | Area | File(s) | What to Cover | Priority | Status | Notes |
@@ -122,6 +122,9 @@
 | Calendar page | `src/pages/Calendar.tsx` | Range filters, session grouping, performance panels | High | Done | Covered by `src/pages/__tests__/Calendar.test.tsx` validating skeleton loading, segmented view switching, and session sheet launch. |
 | Upcoming sessions page | `src/pages/UpcomingSessions.tsx` | Filters, session sorting, empty state messaging | Medium | Done | Covered by `src/pages/__tests__/UpcomingSessions.test.tsx` confirming KPI metrics, segment filters, and session sheet navigation. |
 | Templates workspace | `src/pages/Templates.tsx` | Block editor integration, preview data toggles | Medium | Done | Covered by `src/pages/__tests__/Templates.test.tsx` exercising preview fallbacks, search empty states, row actions, and navigation flows. |
+| Settings services page | `src/pages/settings/Services.tsx` | Tutorial auto-start, section visibility, onboarding completion routing | Medium | Done | Covered by `src/pages/settings/__tests__/Services.test.tsx` verifying tutorial visibility, completion navigation, and exit handling. |
+| Settings projects page | `src/pages/settings/Projects.tsx` | Header metadata, section composition, help content wiring | Low | Done | Covered by `src/pages/settings/__tests__/Projects.test.tsx` ensuring wrapper/sections render with correct header props. |
+| Settings danger zone page | `src/pages/settings/DangerZone.tsx` | Destructive confirmation guardrails, toast messaging, password reset | Medium | Done | Covered by `src/pages/settings/__tests__/DangerZone.test.tsx` exercising password required toast, success flow, and cancel reset. |
 | Session types settings | `src/components/SessionTypesSection.tsx` | CRUD workflows, default selection, empty states | High | Done | Covered by `src/components/__tests__/SessionTypesSection.test.tsx` (empty state, default toggle, activation toggle, deletion). |
 | Session form fields | `src/components/SessionFormFields.tsx` | Validation messaging, timezone-aware inputs, reminders toggles | Medium | Done | Covered by `src/components/__tests__/SessionFormFields.test.tsx` (project selector + field callbacks). |
 | Session status badge | `src/components/SessionStatusBadge.tsx` | Lifecycle color mapping, accessible labels | Low | Done | Covered by `src/components/__tests__/SessionStatusBadge.test.tsx` (loading badge + editable dropdown updates). |
@@ -266,6 +269,7 @@ _Statuses_: `Not started`, `In progress`, `Blocked`, `Ready for review`, `Done`.
 | 2025-11-04 | Codex | Added onboarding modal, workflow sheet, and project preview coverage | Added `src/components/__tests__/OnboardingModal.test.tsx`, `CreateWorkflowSheet.test.tsx`, and `ProjectSheetPreview.test.tsx` to validate modal flows, edit submission payloads, and Supabase-driven previews | Next: Target ProjectSheetView, ActivitySection, and LeadActivitySection components |
 | 2025-11-05 | Codex | Added Project sheet view coverage | `src/components/__tests__/ProjectSheetView.test.tsx` covers data hydration, edit/save flow, and archive confirmation logic with mocked Supabase + toast hooks | Next: Continue with ActivitySection and LeadActivitySection coverage |
 | 2025-11-05 (later) | Codex | Added activity timelines for leads/projects | Added `src/components/__tests__/ActivitySection.test.tsx` and `LeadActivitySection.test.tsx` to validate filter modes, creation toasts, history segments, and completion toggles | Monitor for new activity types or audit entities to extend fixtures |
+| 2025-11-06 | Codex | Hardened settings pages for services, projects, and danger zone flows | Added `src/pages/settings/__tests__/Services.test.tsx`, `Projects.test.tsx`, and `DangerZone.test.tsx` to verify tutorial start/completion, section composition, and destructive guardrails | Follow up by covering `src/pages/settings/General.tsx` and profile/onboarding dialogs |
 
 ## Maintenance Rules of Thumb
 - Treat this file like the single source of truth for unit testing status—update it in the same PR as any test additions or strategy changes.

--- a/src/pages/settings/__tests__/DangerZone.test.tsx
+++ b/src/pages/settings/__tests__/DangerZone.test.tsx
@@ -1,0 +1,161 @@
+import React from "react";
+import { act, fireEvent, render, screen } from "@/utils/testUtils";
+import DangerZone from "../DangerZone";
+import { useToast } from "@/hooks/use-toast";
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock("@/hooks/use-toast", () => ({
+  useToast: jest.fn(),
+}));
+
+jest.mock("@/components/ui/alert-dialog", () => ({
+  __esModule: true,
+  AlertDialog: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="alert-dialog">{children}</div>
+  ),
+  AlertDialogTrigger: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  AlertDialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="alert-dialog-content">{children}</div>
+  ),
+  AlertDialogHeader: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogTitle: ({ children }: { children: React.ReactNode }) => (
+    <h2>{children}</h2>
+  ),
+  AlertDialogDescription: ({ children }: { children: React.ReactNode }) => (
+    <p>{children}</p>
+  ),
+  AlertDialogFooter: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogCancel: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button type="button" onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+  AlertDialogAction: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button type="button" onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+
+const mockUseToast = useToast as jest.Mock;
+
+describe("DangerZone settings page", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("shows a destructive toast when confirming without a password", async () => {
+    const toastSpy = jest.fn();
+    mockUseToast.mockReturnValue({ toast: toastSpy });
+
+    render(<DangerZone />);
+
+    const confirmButton = screen.getAllByRole("button", {
+      name: "settings.dangerZone.deleteData.button",
+    })[1];
+
+    await act(async () => {
+      fireEvent.click(confirmButton);
+    });
+
+    expect(toastSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "settings.dangerZone.deleteData.passwordRequired",
+        description: "settings.dangerZone.deleteData.passwordRequiredDesc",
+        variant: "destructive",
+      })
+    );
+  });
+
+  it("deletes successfully when a password is provided", async () => {
+    jest.useFakeTimers();
+    const toastSpy = jest.fn();
+    mockUseToast.mockReturnValue({ toast: toastSpy });
+
+    render(<DangerZone />);
+
+    const passwordInput = screen.getByLabelText(
+      "settings.dangerZone.deleteData.passwordLabel"
+    );
+    fireEvent.change(passwordInput, { target: { value: "super-secret" } });
+
+    const confirmButton = screen.getAllByRole("button", {
+      name: "settings.dangerZone.deleteData.button",
+    })[1];
+
+    await act(async () => {
+      fireEvent.click(confirmButton);
+    });
+
+    expect(confirmButton).toBeDisabled();
+
+    await act(async () => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(toastSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "settings.dangerZone.deleteData.deleteComplete",
+        description: "settings.dangerZone.deleteData.deleteCompleteDesc",
+        variant: "destructive",
+      })
+    );
+    expect(passwordInput).toHaveValue("");
+  });
+
+  it("clears the password field when cancelling the dialog", () => {
+    const toastSpy = jest.fn();
+    mockUseToast.mockReturnValue({ toast: toastSpy });
+
+    render(<DangerZone />);
+
+    const passwordInput = screen.getByLabelText(
+      "settings.dangerZone.deleteData.passwordLabel"
+    );
+    fireEvent.change(passwordInput, { target: { value: "needs-reset" } });
+
+    const cancelButton = screen.getByRole("button", {
+      name: "settings.dangerZone.deleteData.cancel",
+    });
+
+    fireEvent.click(cancelButton);
+
+    expect(passwordInput).toHaveValue("");
+    expect(toastSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/settings/__tests__/Projects.test.tsx
+++ b/src/pages/settings/__tests__/Projects.test.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { render, screen } from "@/utils/testUtils";
+import Projects from "../Projects";
+import { settingsHelpContent } from "@/lib/settingsHelpContent";
+
+const mockSettingsHeader = jest.fn(() => <div data-testid="settings-header" />);
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock("@/components/settings/SettingsHeader", () => ({
+  __esModule: true,
+  default: (props: any) => mockSettingsHeader(props),
+}));
+
+jest.mock("@/components/settings/SettingsPageWrapper", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="settings-page-wrapper">{children}</div>
+  ),
+}));
+
+jest.mock("@/components/ProjectStatusesSection", () => ({
+  __esModule: true,
+  default: () => <div data-testid="project-statuses-section" />,
+}));
+
+jest.mock("@/components/ProjectTypesSection", () => ({
+  __esModule: true,
+  default: () => <div data-testid="project-types-section" />,
+}));
+
+jest.mock("@/components/SessionStatusesSection", () => ({
+  __esModule: true,
+  default: () => <div data-testid="session-statuses-section" />,
+}));
+
+describe("Projects settings page", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders all project-related settings sections", () => {
+    render(<Projects />);
+
+    expect(screen.getByTestId("settings-page-wrapper")).toBeInTheDocument();
+    expect(screen.getByTestId("project-statuses-section")).toBeInTheDocument();
+    expect(screen.getByTestId("project-types-section")).toBeInTheDocument();
+    expect(screen.getByTestId("session-statuses-section")).toBeInTheDocument();
+
+    expect(mockSettingsHeader).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "settings.projects.title",
+        description: "settings.projects.description",
+        helpContent: settingsHelpContent.projects,
+      }),
+      {}
+    );
+  });
+});

--- a/src/pages/settings/__tests__/Services.test.tsx
+++ b/src/pages/settings/__tests__/Services.test.tsx
@@ -1,0 +1,162 @@
+import React from "react";
+import { act, fireEvent, render, screen, waitFor } from "@/utils/testUtils";
+import Services from "../Services";
+import { settingsHelpContent } from "@/lib/settingsHelpContent";
+
+const mockSettingsHeader = jest.fn(() => <div data-testid="settings-header" />);
+const mockUseOnboarding = jest.fn();
+const mockNavigate = jest.fn();
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock("@/contexts/OnboardingContext", () => ({
+  useOnboarding: () => mockUseOnboarding(),
+}));
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock("@/components/settings/SettingsHeader", () => ({
+  __esModule: true,
+  default: (props: any) => mockSettingsHeader(props),
+}));
+
+jest.mock("@/components/settings/SettingsPageWrapper", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="settings-page-wrapper">{children}</div>
+  ),
+}));
+
+jest.mock("@/components/SessionTypesSection", () => ({
+  __esModule: true,
+  default: () => <div data-testid="session-types-section" />,
+}));
+
+jest.mock("@/components/PackagesSection", () => ({
+  __esModule: true,
+  default: () => <div data-testid="packages-section" />,
+}));
+
+jest.mock("@/components/ServicesSection", () => ({
+  __esModule: true,
+  default: () => <div data-testid="services-section" />,
+}));
+
+const mockOnboardingTutorial = jest.fn(
+  ({ isVisible, onComplete, onExit }: any) => (
+    <div data-testid="onboarding-tutorial" data-visible={isVisible}>
+      <button type="button" data-testid="complete-tutorial" onClick={onComplete}>
+        complete
+      </button>
+      <button type="button" data-testid="exit-tutorial" onClick={onExit}>
+        exit
+      </button>
+    </div>
+  )
+);
+
+jest.mock("@/components/shared/OnboardingTutorial", () => ({
+  OnboardingTutorial: (props: any) => mockOnboardingTutorial(props),
+}));
+
+describe("Services settings page", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseOnboarding.mockReturnValue({
+      currentStep: 6,
+      completeCurrentStep: jest.fn().mockResolvedValue(undefined),
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("shows all service management sections and starts the tutorial when on step six", () => {
+    render(<Services />);
+
+    expect(screen.getByTestId("settings-page-wrapper")).toBeInTheDocument();
+    expect(screen.getByTestId("session-types-section")).toBeInTheDocument();
+    expect(screen.getByTestId("packages-section")).toBeInTheDocument();
+    expect(screen.getByTestId("services-section")).toBeInTheDocument();
+
+    expect(mockSettingsHeader).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "settings.services.title",
+        description: "settings.services.description",
+        helpContent: settingsHelpContent.services,
+      }),
+      {}
+    );
+
+    expect(mockOnboardingTutorial).toHaveBeenCalledWith(
+      expect.objectContaining({ isVisible: true }),
+    );
+    expect(screen.getByTestId("onboarding-tutorial")).toHaveAttribute(
+      "data-visible",
+      "true"
+    );
+  });
+
+  it("completes the tutorial and navigates to getting started", async () => {
+    jest.useFakeTimers();
+    const completeCurrentStep = jest
+      .fn()
+      .mockResolvedValue(undefined);
+
+    mockUseOnboarding.mockReturnValue({
+      currentStep: 6,
+      completeCurrentStep,
+    });
+
+    render(<Services />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("complete-tutorial"));
+    });
+
+    await waitFor(() => expect(completeCurrentStep).toHaveBeenCalled());
+
+    expect(screen.getByTestId("onboarding-tutorial")).toHaveAttribute(
+      "data-visible",
+      "false"
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith("/getting-started");
+  });
+
+  it("hides the tutorial without completing when exiting", async () => {
+    const completeCurrentStep = jest
+      .fn()
+      .mockResolvedValue(undefined);
+
+    mockUseOnboarding.mockReturnValue({
+      currentStep: 6,
+      completeCurrentStep,
+    });
+
+    render(<Services />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("exit-tutorial"));
+    });
+
+    expect(screen.getByTestId("onboarding-tutorial")).toHaveAttribute(
+      "data-visible",
+      "false"
+    );
+    expect(completeCurrentStep).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add targeted unit tests for the settings Danger Zone, Projects, and Services pages to validate destructive safeguards, section wiring, and onboarding tutorials
- update the unit testing tracker progress snapshot and iteration log with the new settings coverage entries

## Testing
- ⚠️ `npm test -- settings` *(blocked: local npm install cannot fetch @esbuild/linux-x64, so Jest is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fcf441dab08321bb525e2fc7df3cc9