### PR TITLE
Add recovery entry test and document password follow-ups

### DIFF
--- a/docs/password-recovery-todo.md
+++ b/docs/password-recovery-todo.md
@@ -1,0 +1,5 @@
+# Password Recovery Flow Follow-Ups
+
+- [ ] Confirm Supabase email recovery redirect preserves `type=recovery` until password is updated.
+- [ ] Audit backend/session handling to ensure recovery link cannot silently log users in without forcing a password change.
+- [ ] Add UX copy to clarify password creation expectations after recovery (EN + TR locales).

--- a/docs/unit-testing-plan.md
+++ b/docs/unit-testing-plan.md
@@ -39,10 +39,10 @@
 | Core Libraries & Helpers | 13 | 13 | 100% |
 | Services & Data Access | 5 | 5 | 100% |
 | Contexts & Hooks | 24 | 24 | 100% |
-| UI Components & Pages | 48 | 48 | 100% |
+| UI Components & Pages | 49 | 49 | 100% |
 | UI Primitives & Shared Components | 17 | 17 | 100% |
 | Supabase Edge Functions & Automation | 9 | 9 | 100% |
-| **Overall** | **116** | **116** | **100%** |
+| **Overall** | **117** | **117** | **100%** |
 
 ### Core Libraries & Helpers
 | Area | File(s) | What to Cover | Priority | Status | Notes |
@@ -112,7 +112,7 @@
 | Protected route guard | `src/components/ProtectedRoute.tsx` | Auth gating, redirect logic, loading fallback | Medium | Done | Covered by `src/components/__tests__/ProtectedRoute.test.tsx` (loading/redirect + onboarding guard). |
 | Route prefetcher | `src/components/RoutePrefetcher.tsx` | Prefetch orchestration, duplicate avoidance | Medium | Done | Covered by `src/components/__tests__/RoutePrefetcher.test.tsx` (cache guard + Supabase prefetch). |
 | Offline banner | `src/components/OfflineBanner.tsx` | Connectivity context integration, retry actions | Low | Done | Covered by `src/components/__tests__/OfflineBanner.test.tsx` (online skip + retry + spinner state). |
-| Auth page | `src/pages/Auth.tsx` | Sign-in/sign-up flows, password recovery, onboarding carousel toggles | High | Done | Covered by `src/pages/__tests__/Auth.test.tsx` for sign-in, sign-up, reset request, and recovery update flows. |
+| Auth page | `src/pages/Auth.tsx` | Sign-in/sign-up flows, password recovery, onboarding carousel toggles | High | Done | Covered by `src/pages/__tests__/Auth.test.tsx` for sign-in, sign-up, reset request, recovery update flows, and recovery entry guard. |
 | Lead detail page | `src/pages/LeadDetail.tsx` | Data loading, tab switching, error fallbacks | High | Done | Covered by `src/pages/__tests__/LeadDetail.test.tsx` for skeleton fallback, summary wiring, status actions, and fetch error toasts. |
 | Project detail page | `src/pages/ProjectDetail.tsx` | Combined queries, session/payment sections, modals | High | Done | Covered by `src/pages/__tests__/ProjectDetail.test.tsx` for happy path rendering + missing project redirect toast. |
 | All leads workspace | `src/pages/AllLeads.tsx` | Server-driven table pagination/sorting, filter chip derivation, KPI metric calculations, onboarding tutorial triggers | High | Done | Covered by `src/pages/__tests__/AllLeads.test.tsx` verifying filter mapping, export disable/re-enable flow, and tutorial completion navigation. |

--- a/src/pages/__tests__/Auth.test.tsx
+++ b/src/pages/__tests__/Auth.test.tsx
@@ -96,6 +96,7 @@ beforeEach(() => {
 afterEach(() => {
   jest.useRealTimers();
   window.location.hash = "";
+  window.history.replaceState(null, "", "/");
 });
 
 describe("Auth page", () => {
@@ -327,5 +328,18 @@ describe("Auth page", () => {
     expect(toastMock.error).toHaveBeenCalledWith("auth.password_mismatch");
 
     expect(getAuthMock().updateUser).not.toHaveBeenCalled();
+  });
+
+  it("shows the password reset flow when returning from the recovery email", async () => {
+    window.history.replaceState(null, "", "/auth?type=recovery");
+
+    render(<Auth />);
+
+    expect(await screen.findByLabelText("labels.password")).toBeInTheDocument();
+    expect(screen.getByLabelText("labels.confirm_password")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "auth.sign_in.button" })).not.toBeInTheDocument();
+
+    expect(getAuthMock().signInWithPassword).not.toHaveBeenCalled();
+    expect(navigateMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add a Jest coverage path to ensure the recovery redirect shows the password reset form instead of auto-login
- reset window location state between specs to avoid leaking recovery params across tests
- refresh the unit-testing tracker snapshot and capture a password recovery follow-up checklist

## Testing
- npm test -- Auth

------
https://chatgpt.com/codex/tasks/task_e_68fcf989a4e88321b485036a25a0400b