### PR TITLE
Add payments workspace hook tests

### DIFF
--- a/docs/unit-testing-plan.md
+++ b/docs/unit-testing-plan.md
@@ -38,11 +38,11 @@
 | --- | --- | --- | --- |
 | Core Libraries & Helpers | 13 | 13 | 100% |
 | Services & Data Access | 5 | 5 | 100% |
-| Contexts & Hooks | 24 | 27 | 89% |
+| Contexts & Hooks | 27 | 27 | 100% |
 | UI Components & Pages | 49 | 70 | 70% |
 | UI Primitives & Shared Components | 17 | 17 | 100% |
 | Supabase Edge Functions & Automation | 9 | 9 | 100% |
-| **Overall** | **117** | **141** | **83%** |
+| **Overall** | **120** | **141** | **85%** |
 
 ### Core Libraries & Helpers
 | Area | File(s) | What to Cover | Priority | Status | Notes |
@@ -81,7 +81,7 @@
 | Session actions | `src/hooks/useSessionActions.ts` | Reminder cleanup, workflow triggers on status change | High | Done | Covered via `src/hooks/__tests__/useSessionActions.test.tsx` for delete failure + status update flows. |
 | Entity data helper | `src/hooks/useEntityData.ts` | Error propagation, dependency refresh behavior | Medium | Done | Covered by `src/hooks/__tests__/useEntityData.test.tsx` for toast fallback, dependency refetch, and custom error handlers. |
 | User preferences hook | `src/hooks/useUserPreferences.ts` | Default bootstrap, optimistic updates, retry strategy | High | Done | Covered by `src/hooks/__tests__/useUserPreferences.test.ts` for bootstrap, defaults, optimistic + helper flows. |
-| Payments workspace hooks | `src/pages/payments/hooks/usePaymentsData.ts`, `usePaymentsFilters.tsx`, `usePaymentsTableColumns.tsx` | Data fetching fallbacks, filter persistence, column memoization | High | Not started | No tests under `src/pages/payments/`; cover Supabase RPC wiring, pagination, and filter sync behavior. |
+| Payments workspace hooks | `src/pages/payments/hooks/usePaymentsData.ts`, `usePaymentsFilters.tsx`, `usePaymentsTableColumns.tsx` | Data fetching fallbacks, filter persistence, column memoization | High | Done | Covered by `src/pages/payments/hooks/__tests__/usePaymentsData.test.ts`, `usePaymentsFilters.test.tsx`, and `usePaymentsTableColumns.test.tsx` validating Supabase query composition, search/amount filter thresholds, and interactive column renderers. |
 | Auth provider | `src/contexts/AuthContext.tsx` | Role fetching, auth change handling, sign-out side effects | High | Done | Covered by `src/contexts/__tests__/AuthContext.test.tsx` (session bootstrap + role fetch + sign-out). |
 | Organization provider | `src/contexts/OrganizationContext.tsx` | Initial load, presence heartbeat cleanup, data prefetch | High | Done | Covered by `src/contexts/__tests__/OrganizationContext.test.tsx` (bootstrap fetch + refresh toast trigger). |
 | Onboarding provider | `src/contexts/OnboardingContext.tsx` | Computed flags, guarded transitions, batch completion | Medium | Done | Covered by `src/contexts/__tests__/OnboardingContext.test.tsx` (computed flags + action guardrails). |
@@ -283,6 +283,7 @@ _Statuses_: `Not started`, `In progress`, `Blocked`, `Ready for review`, `Done`.
 | 2025-11-05 (later) | Codex | Added activity timelines for leads/projects | Added `src/components/__tests__/ActivitySection.test.tsx` and `LeadActivitySection.test.tsx` to validate filter modes, creation toasts, history segments, and completion toggles | Monitor for new activity types or audit entities to extend fixtures |
 | 2025-11-06 | Codex | Hardened settings pages for services, projects, and danger zone flows | Added `src/pages/settings/__tests__/Services.test.tsx`, `Projects.test.tsx`, and `DangerZone.test.tsx` to verify tutorial start/completion, section composition, and destructive guardrails | Follow up by covering `src/pages/settings/General.tsx` and profile/onboarding dialogs |
 | 2025-11-08 | Codex | Audited coverage against current repo state | Updated progress snapshot and backlog rows for onboarding, payments, admin, and remaining settings screens/components with no tests | Assign owners for new high-priority gaps |
+| 2025-11-09 | Codex | Added payments workspace hook coverage | `src/pages/payments/hooks/__tests__/usePaymentsData.test.ts`, `usePaymentsFilters.test.tsx`, and `usePaymentsTableColumns.test.tsx` lock Supabase pagination/search filters, draft thresholds, and column callbacks | Track future payments analytics or virtualization enhancements |
 
 ## Maintenance Rules of Thumb
 - Treat this file like the single source of truth for unit testing status—update it in the same PR as any test additions or strategy changes.

--- a/src/pages/payments/hooks/__tests__/usePaymentsData.test.ts
+++ b/src/pages/payments/hooks/__tests__/usePaymentsData.test.ts
@@ -1,0 +1,527 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+
+jest.mock("@/integrations/supabase/client", () => {
+  const from = jest.fn();
+  return {
+    supabase: {
+      from,
+      rpc: jest.fn(),
+      auth: {
+        getUser: jest.fn(),
+        signIn: jest.fn(),
+        signOut: jest.fn(),
+      },
+    },
+  };
+});
+
+import { supabase } from "@/integrations/supabase/client";
+import type {
+  Payment,
+  PaymentStatusFilter,
+  PaymentTypeFilter,
+  SortDirection,
+  SortField,
+} from "../../types";
+import { PROJECT_SELECT_FIELDS } from "../../constants";
+import { usePaymentsData } from "../usePaymentsData";
+
+const supabaseFromMock = supabase.from as jest.Mock;
+
+type QueryResult = {
+  data: unknown;
+  error: unknown;
+  count?: number | null;
+};
+
+const createQueryBuilder = <T extends QueryResult>(result: T) => {
+  const builder: any = {
+    select: jest.fn(() => builder),
+    ilike: jest.fn(() => builder),
+    in: jest.fn(() => builder),
+    or: jest.fn(() => builder),
+    gte: jest.fn(() => builder),
+    lte: jest.fn(() => builder),
+    order: jest.fn(() => builder),
+    range: jest.fn(() => builder),
+    eq: jest.fn(() => builder),
+  };
+
+  builder.then = (onFulfilled?: (value: T) => unknown, onRejected?: (reason: unknown) => unknown) =>
+    Promise.resolve(result).then(onFulfilled, onRejected);
+  builder.catch = (onRejected?: (reason: unknown) => unknown) =>
+    Promise.resolve(result).catch(onRejected);
+  builder[Symbol.toStringTag] = "Promise";
+  return builder;
+};
+
+type QueryBuilder = ReturnType<typeof createQueryBuilder>;
+
+type QueueMap = Record<"payments" | "projects" | "leads", QueryBuilder[]>;
+
+describe("usePaymentsData", () => {
+  const baseProps = {
+    page: 1,
+    pageSize: 2,
+    sortField: "project_name" as SortField,
+    sortDirection: "asc" as SortDirection,
+    statusFilters: [] as PaymentStatusFilter[],
+    typeFilters: [] as PaymentTypeFilter[],
+    amountMinFilter: null,
+    amountMaxFilter: null,
+    searchTerm: "",
+    activeDateRange: null,
+  };
+
+  let queues: QueueMap;
+  let onError: jest.Mock;
+
+  const enqueue = (table: keyof QueueMap, builder: QueryBuilder) => {
+    queues[table].push(builder);
+    return builder;
+  };
+
+  beforeEach(() => {
+    queues = {
+      payments: [],
+      projects: [],
+      leads: [],
+    };
+    onError = jest.fn();
+    supabaseFromMock.mockReset();
+    supabaseFromMock.mockImplementation((table: string) => {
+      const key = table as keyof QueueMap;
+      const queue = queues[key];
+      if (!queue?.length) {
+        throw new Error(`No mock registered for table ${table}`);
+      }
+      return queue.shift()!;
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("fetches payments, hydrates related entities, and appends subsequent pages", async () => {
+    const tablePayments: Payment[] = [
+      {
+        id: "payment-b",
+        amount: 220,
+        date_paid: "2024-04-10T00:00:00Z",
+        status: "paid",
+        description: "Second",
+        type: "extra",
+        project_id: "project-b",
+        created_at: "2024-04-01T00:00:00Z",
+        projects: null,
+      },
+      {
+        id: "payment-a",
+        amount: 120,
+        date_paid: "2024-04-08T00:00:00Z",
+        status: "due",
+        description: "First",
+        type: "base_price",
+        project_id: "project-a",
+        created_at: "2024-03-01T00:00:00Z",
+        projects: null,
+      },
+    ];
+
+    const metricsPayments: Payment[] = [
+      {
+        id: "metric-1",
+        amount: 220,
+        date_paid: "2024-04-10T00:00:00Z",
+        status: "paid",
+        description: null,
+        type: "extra",
+        project_id: "project-b",
+        created_at: "2024-04-01T00:00:00Z",
+        projects: null,
+      },
+    ];
+
+    const projectsResult = [
+      {
+        id: "project-a",
+        name: "Alpha Project",
+        base_price: 100,
+        lead_id: "lead-a",
+        status_id: null,
+        previous_status_id: null,
+        project_type_id: null,
+        description: null,
+        updated_at: "2024-03-05T00:00:00Z",
+        created_at: "2024-02-01T00:00:00Z",
+        user_id: "user-a",
+      },
+      {
+        id: "project-b",
+        name: "Beta Project",
+        base_price: 200,
+        lead_id: "lead-b",
+        status_id: null,
+        previous_status_id: null,
+        project_type_id: null,
+        description: null,
+        updated_at: "2024-04-09T00:00:00Z",
+        created_at: "2024-02-15T00:00:00Z",
+        user_id: "user-b",
+      },
+    ];
+
+    const leadsResult = [
+      { id: "lead-a", name: "Alice" },
+      { id: "lead-b", name: "Bob" },
+    ];
+
+    const tableBuilder = enqueue(
+      "payments",
+      createQueryBuilder({ data: tablePayments, error: null, count: 2 })
+    );
+    const metricsBuilder = enqueue(
+      "payments",
+      createQueryBuilder({ data: metricsPayments, error: null })
+    );
+    const hydrationProjectsBuilder = enqueue(
+      "projects",
+      createQueryBuilder({ data: projectsResult, error: null })
+    );
+    const hydrationLeadsBuilder = enqueue(
+      "leads",
+      createQueryBuilder({ data: leadsResult, error: null })
+    );
+
+    const { result, rerender } = renderHook(
+      (props: typeof baseProps & { onError: (error: Error) => void }) =>
+        usePaymentsData(props),
+      {
+        initialProps: { ...baseProps, onError },
+      }
+    );
+
+    await waitFor(() => expect(result.current.initialLoading).toBe(false));
+    await waitFor(() => expect(result.current.tableLoading).toBe(false));
+
+    expect(result.current.totalCount).toBe(2);
+    expect(result.current.metricsPayments).toEqual(metricsPayments);
+    expect(result.current.paginatedPayments.map((payment) => payment.projects?.name)).toEqual([
+      "Alpha Project",
+      "Beta Project",
+    ]);
+    expect(result.current.paginatedPayments[0]?.projects?.leads?.name).toBe("Alice");
+    expect(result.current.paginatedPayments[1]?.projects?.leads?.name).toBe("Bob");
+
+    expect(tableBuilder.select).toHaveBeenCalledWith("*", { count: "exact" });
+    expect(tableBuilder.range).toHaveBeenCalledWith(0, 1);
+    expect(tableBuilder.order).toHaveBeenCalledWith("created_at", { ascending: false });
+    expect(metricsBuilder.select).toHaveBeenCalledWith(
+      "id, amount, status, type, date_paid, created_at, project_id"
+    );
+    expect(hydrationProjectsBuilder.select).toHaveBeenCalledWith(PROJECT_SELECT_FIELDS);
+    expect(hydrationProjectsBuilder.in).toHaveBeenCalledWith("id", [
+      "project-b",
+      "project-a",
+    ]);
+    expect(hydrationLeadsBuilder.select).toHaveBeenCalledWith("id, name");
+    expect(hydrationLeadsBuilder.in).toHaveBeenCalledWith("id", ["lead-a", "lead-b"]);
+
+    const nextPayments: Payment[] = [
+      {
+        id: "payment-c",
+        amount: 320,
+        date_paid: "2024-04-12T00:00:00Z",
+        status: "paid",
+        description: "Third",
+        type: "manual",
+        project_id: "project-c",
+        created_at: "2024-04-11T00:00:00Z",
+        projects: null,
+      },
+    ];
+
+    const nextMetrics: Payment[] = [
+      {
+        id: "metric-2",
+        amount: 320,
+        date_paid: "2024-04-12T00:00:00Z",
+        status: "paid",
+        description: null,
+        type: "manual",
+        project_id: "project-c",
+        created_at: "2024-04-11T00:00:00Z",
+        projects: null,
+      },
+    ];
+
+    const nextTableBuilder = enqueue(
+      "payments",
+      createQueryBuilder({ data: nextPayments, error: null, count: 3 })
+    );
+    const nextMetricsBuilder = enqueue(
+      "payments",
+      createQueryBuilder({ data: nextMetrics, error: null })
+    );
+    enqueue(
+      "projects",
+      createQueryBuilder({
+        data: [
+          {
+            id: "project-c",
+            name: "Delta Project",
+            base_price: 300,
+            lead_id: "lead-c",
+            status_id: null,
+            previous_status_id: null,
+            project_type_id: null,
+            description: null,
+            updated_at: "2024-04-12T00:00:00Z",
+            created_at: "2024-04-10T00:00:00Z",
+            user_id: "user-c",
+          },
+        ],
+        error: null,
+      })
+    );
+    enqueue(
+      "leads",
+      createQueryBuilder({ data: [{ id: "lead-c", name: "Charlie" }], error: null })
+    );
+
+    rerender({ ...baseProps, page: 2, onError });
+
+    await waitFor(() => expect(result.current.tableLoading).toBe(false));
+    await waitFor(() => expect(result.current.paginatedPayments).toHaveLength(1));
+
+    expect(result.current.paginatedPayments[0]?.projects?.name).toBe("Delta Project");
+    expect(result.current.paginatedPayments[0]?.projects?.leads?.name).toBe("Charlie");
+    expect(result.current.totalCount).toBe(3);
+    expect(result.current.metricsPayments).toEqual(nextMetrics);
+    expect(nextMetricsBuilder.select).toHaveBeenCalledWith(
+      "id, amount, status, type, date_paid, created_at, project_id"
+    );
+    expect(nextTableBuilder.range).toHaveBeenCalledWith(2, 3);
+    expect(queues.payments).toHaveLength(0);
+  });
+
+  it("applies search, type, and amount filters when fetching data", async () => {
+    const searchProjectsBuilder = enqueue(
+      "projects",
+      createQueryBuilder({
+        data: [
+          {
+            id: "project-30",
+            name: "Omega",
+            base_price: 100,
+            lead_id: "lead-30",
+            status_id: null,
+            previous_status_id: null,
+            project_type_id: null,
+            description: null,
+            updated_at: "2024-03-01T00:00:00Z",
+            created_at: "2024-02-01T00:00:00Z",
+            user_id: "user-30",
+          },
+          {
+            id: "project-40",
+            name: "Sigma",
+            base_price: 120,
+            lead_id: "lead-40",
+            status_id: null,
+            previous_status_id: null,
+            project_type_id: null,
+            description: null,
+            updated_at: "2024-03-02T00:00:00Z",
+            created_at: "2024-02-02T00:00:00Z",
+            user_id: "user-40",
+          },
+        ],
+        error: null,
+      })
+    );
+    const searchLeadsBuilder = enqueue(
+      "leads",
+      createQueryBuilder({
+        data: [
+          { id: "lead-30", name: "Olive" },
+          { id: "lead-40", name: "Orion" },
+        ],
+        error: null,
+      })
+    );
+    const projectsForLeadsBuilder = enqueue(
+      "projects",
+      createQueryBuilder({
+        data: [
+          {
+            id: "project-50",
+            name: "Tau",
+            base_price: 200,
+            lead_id: "lead-50",
+            status_id: null,
+            previous_status_id: null,
+            project_type_id: null,
+            description: null,
+            updated_at: "2024-03-03T00:00:00Z",
+            created_at: "2024-02-03T00:00:00Z",
+            user_id: "user-50",
+          },
+        ],
+        error: null,
+      })
+    );
+    const hydrationSearchLeadsBuilder = enqueue(
+      "leads",
+      createQueryBuilder({
+        data: [{ id: "lead-50", name: "Tessa" }],
+        error: null,
+      })
+    );
+
+    const tableBuilder = enqueue(
+      "payments",
+      createQueryBuilder({
+        data: [
+          {
+            id: "payment-newer",
+            amount: 400,
+            date_paid: "2024-05-05T00:00:00Z",
+            status: "paid",
+            description: "Newest",
+            type: "extra",
+            project_id: "project-40",
+            created_at: "2024-05-01T00:00:00Z",
+            projects: null,
+          },
+          {
+            id: "payment-older",
+            amount: 80,
+            date_paid: "2024-04-01T00:00:00Z",
+            status: "paid",
+            description: "Older",
+            type: "extra",
+            project_id: "project-30",
+            created_at: "2024-03-01T00:00:00Z",
+            projects: null,
+          },
+        ],
+        error: null,
+        count: 2,
+      })
+    );
+
+    const metricsBuilder = enqueue(
+      "payments",
+      createQueryBuilder({
+        data: [
+          {
+            id: "payment-metric",
+            amount: 400,
+            date_paid: "2024-05-05T00:00:00Z",
+            status: "paid",
+            description: null,
+            type: "extra",
+            project_id: "project-40",
+            created_at: "2024-05-01T00:00:00Z",
+            projects: null,
+          },
+        ],
+        error: null,
+      })
+    );
+
+    const { result } = renderHook(
+      (props: typeof baseProps & { onError: (error: Error) => void }) =>
+        usePaymentsData(props),
+      {
+        initialProps: {
+          ...baseProps,
+          pageSize: 25,
+          sortField: "date_paid",
+          sortDirection: "desc",
+          statusFilters: ["paid"],
+          typeFilters: ["extra"],
+          amountMinFilter: 50,
+          amountMaxFilter: 500,
+          searchTerm: 'Pro "Alpha"',
+          onError,
+        },
+      }
+    );
+
+    await waitFor(() => expect(result.current.initialLoading).toBe(false));
+    await waitFor(() => expect(result.current.tableLoading).toBe(false));
+
+    expect(searchProjectsBuilder.select).toHaveBeenCalledWith(PROJECT_SELECT_FIELDS);
+    expect(searchProjectsBuilder.ilike).toHaveBeenCalledWith("name", "%Pro \"Alpha\"%");
+    expect(searchLeadsBuilder.select).toHaveBeenCalledWith("id, name");
+    expect(searchLeadsBuilder.ilike).toHaveBeenCalledWith("name", "%Pro \"Alpha\"%");
+    expect(projectsForLeadsBuilder.select).toHaveBeenCalledWith(PROJECT_SELECT_FIELDS);
+    expect(projectsForLeadsBuilder.in).toHaveBeenCalledWith("lead_id", ["lead-30", "lead-40"]);
+    expect(hydrationSearchLeadsBuilder.select).toHaveBeenCalledWith("id, name");
+    expect(hydrationSearchLeadsBuilder.in).toHaveBeenCalledWith("id", ["lead-50"]);
+
+    expect(tableBuilder.select).toHaveBeenCalledWith("*", { count: "exact" });
+    expect(tableBuilder.ilike).toHaveBeenCalledWith("status", "paid");
+    expect(tableBuilder.in).toHaveBeenCalledWith("type", ["extra"]);
+    expect(tableBuilder.gte).toHaveBeenCalledWith("amount", 50);
+    expect(tableBuilder.lte).toHaveBeenCalledWith("amount", 500);
+    expect(tableBuilder.or).toHaveBeenCalledWith(
+      expect.stringContaining("project_id.in.(project-30,project-40,project-50)")
+    );
+    expect(tableBuilder.or).toHaveBeenCalledWith(
+      expect.stringContaining('description.ilike."%Pro ""Alpha""%"')
+    );
+    expect(tableBuilder.order).toHaveBeenNthCalledWith(1, "date_paid", {
+      ascending: false,
+      nullsLast: true,
+    });
+    expect(tableBuilder.order).toHaveBeenNthCalledWith(2, "created_at", {
+      ascending: false,
+    });
+    expect(tableBuilder.range).toHaveBeenCalledWith(0, 24);
+
+    expect(metricsBuilder.select).toHaveBeenCalledWith(
+      "id, amount, status, type, date_paid, created_at, project_id"
+    );
+    expect(metricsBuilder.ilike).toHaveBeenCalledWith("status", "paid");
+    expect(metricsBuilder.in).toHaveBeenCalledWith("type", ["extra"]);
+    expect(metricsBuilder.gte).toHaveBeenCalledWith("amount", 50);
+    expect(metricsBuilder.lte).toHaveBeenCalledWith("amount", 500);
+    expect(metricsBuilder.or).toHaveBeenCalledWith(
+      expect.stringContaining("project_id.in.(project-30,project-40,project-50)")
+    );
+
+    await waitFor(() => expect(result.current.paginatedPayments).toHaveLength(2));
+    expect(result.current.paginatedPayments[0]?.id).toBe("payment-newer");
+    expect(result.current.totalCount).toBe(2);
+  });
+
+  it("surfaces Supabase errors through the provided handler", async () => {
+    const failingBuilder = enqueue(
+      "payments",
+      createQueryBuilder({
+        data: null,
+        error: new Error("payments fetch failed"),
+      })
+    );
+
+    const { result } = renderHook(
+      (props: typeof baseProps & { onError: (error: Error) => void }) =>
+        usePaymentsData(props),
+      {
+        initialProps: { ...baseProps, onError },
+      }
+    );
+
+    await waitFor(() => expect(onError).toHaveBeenCalled());
+
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: "payments fetch failed" }));
+    expect(result.current.initialLoading).toBe(false);
+    expect(result.current.tableLoading).toBe(false);
+    expect(result.current.paginatedPayments).toHaveLength(0);
+    expect(failingBuilder.range).toHaveBeenCalledWith(0, 1);
+  });
+});

--- a/src/pages/payments/hooks/__tests__/usePaymentsFilters.test.tsx
+++ b/src/pages/payments/hooks/__tests__/usePaymentsFilters.test.tsx
@@ -1,0 +1,150 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+import type { PaymentsFiltersState } from "../usePaymentsFilters";
+import { usePaymentsFilters } from "../usePaymentsFilters";
+import type { PaymentStatusFilter, PaymentTypeFilter } from "../../types";
+
+describe("usePaymentsFilters", () => {
+  const buildState = (overrides: Partial<PaymentsFiltersState> = {}): PaymentsFiltersState => ({
+    status: [],
+    type: [],
+    amountMin: null,
+    amountMax: null,
+    search: "",
+    ...overrides,
+  });
+
+  it("initializes with normalized state and counts active filters", () => {
+    const initialState = buildState({
+      status: ["paid" satisfies PaymentStatusFilter],
+      type: ["manual" satisfies PaymentTypeFilter],
+      amountMin: 25,
+      amountMax: 75,
+      search: "existing",
+    });
+
+    const { result } = renderHook(() =>
+      usePaymentsFilters({
+        initialState,
+      })
+    );
+
+    expect(result.current.state).toEqual(initialState);
+    expect(result.current.searchValue).toBe("existing");
+    expect(result.current.activeFilterCount).toBe(4);
+    expect(result.current.filtersConfig.activeCount).toBe(4);
+    expect(result.current.filtersConfig.onReset).toBeDefined();
+  });
+
+  it("updates search state only when the threshold is met", () => {
+    const onStateChange = jest.fn();
+    const { result } = renderHook(() =>
+      usePaymentsFilters({
+        onStateChange,
+      })
+    );
+
+    act(() => {
+      result.current.onSearchChange("hi");
+    });
+
+    expect(onStateChange).not.toHaveBeenCalled();
+    expect(result.current.state.search).toBe("");
+
+    act(() => {
+      result.current.onSearchChange("   ready   ");
+    });
+
+    expect(onStateChange).toHaveBeenCalledTimes(1);
+    expect(onStateChange.mock.calls[0][1].reason).toBe("search");
+    expect(result.current.state.search).toBe("ready");
+    expect(result.current.searchValue).toBe("   ready   ");
+
+    onStateChange.mockClear();
+
+    act(() => {
+      result.current.onSearchClear();
+    });
+
+    expect(onStateChange).toHaveBeenCalledTimes(1);
+    expect(onStateChange.mock.calls[0][1].reason).toBe("search");
+    expect(result.current.state.search).toBe("");
+    expect(result.current.searchValue).toBe("");
+  });
+
+  it("resets filters through the exposed configuration handler", () => {
+    const onStateChange = jest.fn();
+    const initialState = buildState({
+      status: ["due" satisfies PaymentStatusFilter],
+      type: ["base_price" satisfies PaymentTypeFilter],
+      amountMin: 10,
+      amountMax: 50,
+    });
+
+    const { result } = renderHook(() =>
+      usePaymentsFilters({
+        onStateChange,
+        initialState,
+      })
+    );
+
+    act(() => {
+      result.current.onSearchChange("delta");
+    });
+
+    onStateChange.mockClear();
+
+    act(() => {
+      result.current.filtersConfig.onReset?.();
+    });
+
+    expect(onStateChange).toHaveBeenCalledTimes(1);
+    expect(onStateChange.mock.calls[0][1].reason).toBe("reset");
+    expect(result.current.state).toEqual({ ...initialState, search: "" });
+    expect(result.current.searchValue).toBe("");
+    expect(result.current.activeFilterCount).toBe(4);
+  });
+
+  it("synchronizes with incoming initial state changes", async () => {
+    const onStateChange = jest.fn();
+    const { result, rerender } = renderHook(
+      ({ initialState }: { initialState: PaymentsFiltersState }) =>
+        usePaymentsFilters({
+          onStateChange,
+          initialState,
+        }),
+      {
+        initialProps: {
+          initialState: buildState({
+            status: ["paid" satisfies PaymentStatusFilter],
+            search: "alpha",
+          }),
+        },
+      }
+    );
+
+    expect(result.current.state.search).toBe("alpha");
+    expect(result.current.searchValue).toBe("alpha");
+
+    const nextState = buildState({
+      status: ["paid", "due"].map((value) => value as PaymentStatusFilter),
+      type: ["extra" satisfies PaymentTypeFilter],
+      amountMax: 90,
+      search: "due",
+    });
+
+    rerender({ initialState: nextState });
+
+    await waitFor(() => expect(result.current.state.search).toBe("due"));
+
+    expect(result.current.state).toEqual(nextState);
+    expect(result.current.searchValue).toBe("due");
+    expect(result.current.activeFilterCount).toBe(2);
+  });
+});

--- a/src/pages/payments/hooks/__tests__/usePaymentsTableColumns.test.tsx
+++ b/src/pages/payments/hooks/__tests__/usePaymentsTableColumns.test.tsx
@@ -1,0 +1,181 @@
+import { fireEvent, render, renderHook } from "@testing-library/react";
+
+const translationMock = (key: string) => key;
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: translationMock,
+  }),
+}));
+
+jest.mock("@/lib/utils", () => {
+  const actual = jest.requireActual("@/lib/utils");
+  return {
+    ...actual,
+    formatDate: jest.fn(() => "formatted-date"),
+  };
+});
+
+import type { Payment } from "../../types";
+import { usePaymentsTableColumns } from "../usePaymentsTableColumns";
+import { PAYMENT_COLORS } from "@/lib/paymentColors";
+
+const { formatDate } = jest.requireMock("@/lib/utils") as { formatDate: jest.Mock };
+
+describe("usePaymentsTableColumns", () => {
+  const baseRow: Payment = {
+    id: "payment-1",
+    amount: 150,
+    date_paid: "2024-05-10T00:00:00Z",
+    status: "paid",
+    description: "Deposit",
+    type: "base_price",
+    project_id: "project-1",
+    created_at: "2024-05-01T00:00:00Z",
+    projects: {
+      id: "project-1",
+      name: "Aurora",
+      base_price: 150,
+      lead_id: "lead-1",
+      status_id: null,
+      previous_status_id: null,
+      project_type_id: null,
+      description: null,
+      updated_at: undefined,
+      created_at: undefined,
+      user_id: undefined,
+      leads: { id: "lead-1", name: "Lead Name" },
+    },
+  };
+
+  it("provides stable column definitions for identical handlers", () => {
+    const handlers = {
+      onProjectSelect: jest.fn(),
+      onNavigateToLead: jest.fn(),
+      formatAmount: jest.fn((value: number) => `$${value.toFixed(2)}`),
+    };
+
+    const { result, rerender } = renderHook(
+      (props: typeof handlers) =>
+        usePaymentsTableColumns({
+          onProjectSelect: props.onProjectSelect,
+          onNavigateToLead: props.onNavigateToLead,
+          formatAmount: props.formatAmount,
+        }),
+      {
+        initialProps: handlers,
+      }
+    );
+
+    const initialColumns = result.current;
+    expect(initialColumns).toHaveLength(7);
+    expect(initialColumns.map((column) => column.id)).toEqual([
+      "date_paid",
+      "lead",
+      "project",
+      "amount",
+      "description",
+      "status",
+      "type",
+    ]);
+
+    rerender(handlers);
+    expect(result.current).toBe(initialColumns);
+
+    const nextHandlers = {
+      ...handlers,
+      formatAmount: jest.fn((value: number) => `€${value.toFixed(2)}`),
+    };
+
+    rerender(nextHandlers);
+    expect(result.current).not.toBe(initialColumns);
+  });
+
+  it("renders project and lead cells with interactive handlers", () => {
+    const onProjectSelect = jest.fn();
+    const onNavigateToLead = jest.fn();
+    const formatAmount = jest.fn((value: number) => `$${value}`);
+
+    const { result } = renderHook(() =>
+      usePaymentsTableColumns({ onProjectSelect, onNavigateToLead, formatAmount })
+    );
+
+    const columns = result.current;
+    const leadColumn = columns.find((column) => column.id === "lead");
+    const projectColumn = columns.find((column) => column.id === "project");
+    const amountColumn = columns.find((column) => column.id === "amount");
+
+    const leadView = render(leadColumn!.render(baseRow));
+    fireEvent.click(leadView.getByRole("button", { name: "Lead Name" }));
+    expect(onNavigateToLead).toHaveBeenCalledWith("lead-1");
+    leadView.unmount();
+
+    const projectView = render(projectColumn!.render(baseRow));
+    fireEvent.click(projectView.getByRole("button", { name: "Aurora" }));
+    expect(onProjectSelect).toHaveBeenCalledWith(baseRow);
+    projectView.unmount();
+
+    const emptyProjectView = render(projectColumn!.render({ ...baseRow, projects: null }));
+    expect(emptyProjectView.getByText("-")).toBeInTheDocument();
+    emptyProjectView.unmount();
+
+    const emptyLeadView = render(leadColumn!.render({ ...baseRow, projects: null }));
+    expect(emptyLeadView.getByText("-")).toBeInTheDocument();
+    emptyLeadView.unmount();
+
+    const amountView = render(amountColumn!.render(baseRow));
+    expect(formatAmount).toHaveBeenCalledWith(150);
+    expect(amountView.getByText("$150")).toBeInTheDocument();
+    amountView.unmount();
+  });
+
+  it("formats dates and statuses while applying payment colors", () => {
+    const onProjectSelect = jest.fn();
+    const onNavigateToLead = jest.fn();
+    const formatAmount = jest.fn((value: number) => `$${value}`);
+
+    const { result } = renderHook(() =>
+      usePaymentsTableColumns({ onProjectSelect, onNavigateToLead, formatAmount })
+    );
+
+    const columns = result.current;
+    const dateColumn = columns.find((column) => column.id === "date_paid");
+    const statusColumn = columns.find((column) => column.id === "status");
+    const typeColumn = columns.find((column) => column.id === "type");
+
+    formatDate.mockClear();
+    const paidDateView = render(dateColumn!.render(baseRow));
+    expect(formatDate).toHaveBeenCalledWith("2024-05-10T00:00:00Z");
+    expect(paidDateView.getByText("formatted-date")).toBeInTheDocument();
+    paidDateView.unmount();
+
+    const createdDateView = render(dateColumn!.render({ ...baseRow, date_paid: null }));
+    expect(formatDate).toHaveBeenCalledWith("2024-05-01T00:00:00Z");
+    createdDateView.unmount();
+
+    const paidStatusView = render(statusColumn!.render(baseRow));
+    const paidBadge = paidStatusView.getByText("payments.status.paid");
+    PAYMENT_COLORS.paid.badgeClass.split(" ").forEach((className) => {
+      expect(paidBadge).toHaveClass(className);
+    });
+    paidStatusView.unmount();
+
+    const dueStatusView = render(statusColumn!.render({ ...baseRow, status: "due" }));
+    const dueBadge = dueStatusView.getByText("payments.status.due");
+    PAYMENT_COLORS.due.badgeClass.split(" ").forEach((className) => {
+      expect(dueBadge).toHaveClass(className);
+    });
+    dueStatusView.unmount();
+
+    const baseTypeView = render(typeColumn!.render(baseRow));
+    expect(baseTypeView.getByText("payments.type.base")).toBeInTheDocument();
+    baseTypeView.unmount();
+
+    const extraTypeView = render(typeColumn!.render({ ...baseRow, type: "extra" }));
+    expect(extraTypeView.getByText("payments.type.extra")).toBeInTheDocument();
+    extraTypeView.unmount();
+
+    const manualTypeView = render(typeColumn!.render({ ...baseRow, type: "manual" }));
+    expect(manualTypeView.getByText("payments.type.manual")).toBeInTheDocument();
+    manualTypeView.unmount();
+  });
+});


### PR DESCRIPTION
## Summary
- add focused Jest suites for the payments data hook covering Supabase chaining, hydration, and paginated fetches
- exercise payments filter state transitions and payments table column interactions to lock search thresholds and callbacks
- refresh docs/unit-testing-plan.md progress snapshot and iteration log for the newly covered hooks

## Testing
- npm test -- --runTestsByPath src/pages/payments/hooks/__tests__/usePaymentsData.test.ts src/pages/payments/hooks/__tests__/usePaymentsFilters.test.tsx src/pages/payments/hooks/__tests__/usePaymentsTableColumns.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68fd0293d3fc83218bf966650c1178bc