### PR TITLE
Add onboarding landing coverage tests

### DIFF
--- a/docs/unit-testing-plan.md
+++ b/docs/unit-testing-plan.md
@@ -39,10 +39,10 @@
 | Core Libraries & Helpers | 13 | 13 | 100% |
 | Services & Data Access | 5 | 5 | 100% |
 | Contexts & Hooks | 27 | 27 | 100% |
-| UI Components & Pages | 49 | 70 | 70% |
+| UI Components & Pages | 53 | 70 | 76% |
 | UI Primitives & Shared Components | 17 | 17 | 100% |
 | Supabase Edge Functions & Automation | 9 | 9 | 100% |
-| **Overall** | **120** | **141** | **85%** |
+| **Overall** | **124** | **141** | **88%** |
 
 ### Core Libraries & Helpers
 | Area | File(s) | What to Cover | Priority | Status | Notes |
@@ -149,10 +149,10 @@
 | Exit guidance mode button | `src/components/ExitGuidanceModeButton.tsx` | Navigation lock guard, onboarding completion, toast errors | Low | Done | Covered by `src/components/__tests__/ExitGuidanceModeButton.test.tsx` for lock checks, success toast, and failure surfacing. |
 | App sidebar | `src/components/AppSidebar.tsx` | Active route highlighting, role-based menu items | High | Done | Covered by `src/components/__tests__/AppSidebar.test.tsx` for active route styling + admin/support visibility. |
 | User menu | `src/components/UserMenu.tsx` | Avatar fallbacks, settings/sign-out navigation, onboarding callbacks | Medium | Done | Covered by `src/components/__tests__/UserMenu.test.tsx` validating initials rendering, profile link, and sign-out flow. |
-| Sample data modal | `src/components/SampleDataModal.tsx` | Template preview data, apply/reset callbacks, modal dismissal | Medium | Not started | Currently only mocked by `OnboardingModal` tests; add direct coverage for CTA wiring and analytics events. |
-| Getting started onboarding page | `src/pages/GettingStarted.tsx` | Checklist progress, sample data modal toggles, onboarding completion routing | High | Not started | No `src/pages/__tests__/GettingStarted.test.tsx`; verify first-run flows and guardrails. |
-| Marketing landing page | `src/pages/Index.tsx` | Auth-based redirects, CTA links, feature highlights | Medium | Not started | Missing coverage for public landing route; add tests for navigation + feature cards. |
-| Not found route | `src/pages/NotFound.tsx` | Support links, navigation back to dashboard, localization | Low | Not started | Provide regression test for 404 experience; no existing spec. |
+| Sample data modal | `src/components/SampleDataModal.tsx` | Template preview data, apply/reset callbacks, modal dismissal | Medium | Done | Covered by `src/components/__tests__/SampleDataModal.test.tsx` for skip success/error paths and guided setup continuation. |
+| Getting started onboarding page | `src/pages/GettingStarted.tsx` | Checklist progress, sample data modal toggles, onboarding completion routing | High | Done | Covered by `src/pages/__tests__/GettingStarted.test.tsx` exercising redirects, guided progress, modal toggles, and completion flow. |
+| Marketing landing page | `src/pages/Index.tsx` | Auth-based redirects, CTA links, feature highlights | Medium | Done | Covered by `src/pages/__tests__/Index.test.tsx` validating loading skeleton, CRM redirect, and public CTA navigation. |
+| Not found route | `src/pages/NotFound.tsx` | Support links, navigation back to dashboard, localization | Low | Done | Covered by `src/pages/__tests__/NotFound.test.tsx` asserting error logging and dashboard link rendering. |
 | Payments dashboard page | `src/pages/Payments.tsx` | Metrics cards, filters, pagination, workspace toggles | High | Not started | Payments workspace has zero Jest coverage; cover interactions with payments hooks/components. |
 | Reminder details page | `src/pages/ReminderDetails.tsx` | Reminder fetch, status updates, reschedule/cancel flows | High | Not started | Lacks tests for Supabase-driven reminder lifecycle; add success/error scenarios. |
 | Template builder page | `src/pages/TemplateBuilder.tsx` | Editor state management, autosave/publish, preview toggles | High | Not started | No page-level tests; cover memoized content and dirty-state handling. |
@@ -284,6 +284,7 @@ _Statuses_: `Not started`, `In progress`, `Blocked`, `Ready for review`, `Done`.
 | 2025-11-06 | Codex | Hardened settings pages for services, projects, and danger zone flows | Added `src/pages/settings/__tests__/Services.test.tsx`, `Projects.test.tsx`, and `DangerZone.test.tsx` to verify tutorial start/completion, section composition, and destructive guardrails | Follow up by covering `src/pages/settings/General.tsx` and profile/onboarding dialogs |
 | 2025-11-08 | Codex | Audited coverage against current repo state | Updated progress snapshot and backlog rows for onboarding, payments, admin, and remaining settings screens/components with no tests | Assign owners for new high-priority gaps |
 | 2025-11-09 | Codex | Added payments workspace hook coverage | `src/pages/payments/hooks/__tests__/usePaymentsData.test.ts`, `usePaymentsFilters.test.tsx`, and `usePaymentsTableColumns.test.tsx` lock Supabase pagination/search filters, draft thresholds, and column callbacks | Track future payments analytics or virtualization enhancements |
+| 2025-11-10 | Codex | Added onboarding landing coverage for remaining pages | Added `src/components/__tests__/SampleDataModal.test.tsx`, `src/pages/__tests__/GettingStarted.test.tsx`, `Index.test.tsx`, and `NotFound.test.tsx` to exercise modal flows, guided redirects, marketing CTA, and 404 logging | Next: extend coverage to Payments page, ReminderDetails page, and settings context usage |
 
 ## Maintenance Rules of Thumb
 - Treat this file like the single source of truth for unit testing status—update it in the same PR as any test additions or strategy changes.

--- a/src/components/__tests__/SampleDataModal.test.tsx
+++ b/src/components/__tests__/SampleDataModal.test.tsx
@@ -1,0 +1,159 @@
+import userEvent from "@testing-library/user-event";
+import { render, screen, waitFor } from "@/utils/testUtils";
+import { SampleDataModal } from "../SampleDataModal";
+import { useAuth } from "@/contexts/AuthContext";
+import { useOnboarding } from "@/contexts/OnboardingContext";
+import { toast } from "@/hooks/use-toast";
+import { useNavigate } from "react-router-dom";
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: jest.fn(),
+}));
+
+jest.mock("@/contexts/AuthContext", () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock("@/contexts/OnboardingContext", () => ({
+  useOnboarding: jest.fn(),
+}));
+
+jest.mock("@/hooks/use-toast", () => ({
+  toast: jest.fn(),
+}));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const baseModalRender = jest.fn(
+  ({ open, title, description, actions, children }: any) => {
+    if (!open) return null;
+    return (
+      <div data-testid="sample-modal-root">
+        <h1>{title}</h1>
+        <p>{description}</p>
+        <div>{children}</div>
+        <div>
+          {actions?.map((action: any, index: number) => (
+            <button
+              key={index}
+              disabled={action.disabled}
+              onClick={action.onClick}
+            >
+              {action.label}
+            </button>
+          ))}
+        </div>
+      </div>
+    );
+  }
+);
+
+jest.mock("../shared/BaseOnboardingModal", () => ({
+  BaseOnboardingModal: (props: any) => baseModalRender(props),
+}));
+
+const mockUseAuth = useAuth as jest.Mock;
+const mockUseOnboarding = useOnboarding as jest.Mock;
+const mockToast = toast as jest.Mock;
+const mockUseNavigate = useNavigate as jest.Mock;
+
+describe("SampleDataModal", () => {
+  const skipOnboarding = jest.fn();
+  const startGuidedSetup = jest.fn();
+  const navigate = jest.fn();
+  const onClose = jest.fn();
+  const onCloseAll = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    skipOnboarding.mockResolvedValue(undefined);
+    startGuidedSetup.mockResolvedValue(undefined);
+    mockUseAuth.mockReturnValue({ user: { id: "user-1" } });
+    mockUseOnboarding.mockReturnValue({ skipOnboarding, startGuidedSetup });
+    mockToast.mockReturnValue(undefined);
+    mockUseNavigate.mockReturnValue(navigate);
+  });
+
+  it("renders sample data information when open", () => {
+    render(<SampleDataModal open onClose={onClose} />);
+
+    expect(baseModalRender).toHaveBeenCalled();
+    expect(
+      screen.getByText("onboarding.sample_data.items.sample_leads.title")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("onboarding.sample_data.items.example_projects.title")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("onboarding.sample_data.items.scheduled_sessions.title")
+    ).toBeInTheDocument();
+  });
+
+  it("skips onboarding with sample data and shows success feedback", async () => {
+    const user = userEvent.setup();
+    render(<SampleDataModal open onClose={onClose} />);
+
+    const skipButton = screen.getByRole("button", {
+      name: "onboarding.sample_data.start_with_sample_data",
+    });
+
+    await user.click(skipButton);
+
+    await waitFor(() => expect(skipOnboarding).toHaveBeenCalledTimes(1));
+    expect(skipOnboarding).toHaveBeenCalledWith();
+
+    await waitFor(() =>
+      expect(mockToast).toHaveBeenCalledWith({
+        title: "onboarding.sample_data.toast.success_title",
+        description: "onboarding.sample_data.toast.success_description",
+      })
+    );
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledWith("/leads");
+  });
+
+  it("continues guided setup when requested", async () => {
+    const user = userEvent.setup();
+    render(<SampleDataModal open onClose={onClose} onCloseAll={onCloseAll} />);
+
+    const continueButton = screen.getByRole("button", {
+      name: "onboarding.sample_data.continue_guided_setup",
+    });
+
+    await user.click(continueButton);
+
+    await waitFor(() => expect(startGuidedSetup).toHaveBeenCalledTimes(1));
+    expect(onCloseAll).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledWith("/getting-started");
+  });
+
+  it("surfaces toast errors when skipping fails", async () => {
+    const user = userEvent.setup();
+    const error = new Error("boom");
+    skipOnboarding.mockRejectedValueOnce(error);
+
+    render(<SampleDataModal open onClose={onClose} />);
+
+    const skipButton = screen.getByRole("button", {
+      name: "onboarding.sample_data.start_with_sample_data",
+    });
+
+    await user.click(skipButton);
+
+    await waitFor(() => expect(skipOnboarding).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(mockToast).toHaveBeenCalledWith({
+        title: "onboarding.sample_data.toast.error_title",
+        description: "onboarding.sample_data.toast.error_description",
+        variant: "destructive",
+      })
+    );
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/__tests__/GettingStarted.test.tsx
+++ b/src/pages/__tests__/GettingStarted.test.tsx
@@ -1,0 +1,167 @@
+import userEvent from "@testing-library/user-event";
+import { render, screen, waitFor } from "@/utils/testUtils";
+import GettingStarted from "../GettingStarted";
+import { useAuth } from "@/contexts/AuthContext";
+import { useOnboarding } from "@/contexts/OnboardingContext";
+import { useNavigate } from "react-router-dom";
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: jest.fn(),
+}));
+
+jest.mock("@/contexts/AuthContext", () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock("@/contexts/OnboardingContext", () => ({
+  useOnboarding: jest.fn(),
+}));
+
+jest.mock("@/components/SampleDataModal", () => ({
+  SampleDataModal: ({ open, onClose }: any) =>
+    open ? (
+      <div data-testid="sample-data-modal">
+        <button onClick={onClose}>close-sample</button>
+      </div>
+    ) : null,
+}));
+
+jest.mock("@/components/RestartGuidedModeButton", () => ({
+  RestartGuidedModeButton: () => <div data-testid="restart-guided" />,
+}));
+
+jest.mock("@/components/ExitGuidanceModeButton", () => ({
+  ExitGuidanceModeButton: () => <div data-testid="exit-guided" />,
+}));
+
+jest.mock("@/components/GuidedStepProgress", () => ({
+  GuidedStepProgress: (props: any) => (
+    <div data-testid="guided-progress" data-props={JSON.stringify(props)} />
+  ),
+}));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const mockUseAuth = useAuth as jest.Mock;
+const mockUseOnboarding = useOnboarding as jest.Mock;
+const mockUseNavigate = useNavigate as jest.Mock;
+
+const buildOnboardingState = (overrides: Partial<ReturnType<typeof mockUseOnboarding>> = {}) => ({
+  loading: false,
+  isInGuidedSetup: true,
+  isOnboardingComplete: false,
+  currentStepInfo: { id: 1, route: "/leads", title: "Lead" },
+  nextStepInfo: { id: 2, route: "/projects", title: "Project" },
+  completedSteps: [],
+  isAllStepsComplete: false,
+  totalSteps: 5,
+  currentStep: 1,
+  completeOnboarding: jest.fn().mockResolvedValue(undefined),
+  ...overrides,
+});
+
+describe("GettingStarted page", () => {
+  const navigate = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAuth.mockReturnValue({ user: { id: "user-1" } });
+    mockUseNavigate.mockReturnValue(navigate);
+  });
+
+  it("shows loading state while onboarding data is fetching", () => {
+    mockUseOnboarding.mockReturnValue(
+      buildOnboardingState({
+        loading: true,
+        completedSteps: [],
+        currentStepInfo: null,
+        nextStepInfo: null,
+      })
+    );
+
+    render(<GettingStarted />);
+
+    expect(
+      screen.getByText("onboarding.getting_started.loading")
+    ).toBeInTheDocument();
+  });
+
+  it("redirects to dashboard when onboarding already complete", () => {
+    const completeState = buildOnboardingState({
+      loading: false,
+      isInGuidedSetup: false,
+      isOnboardingComplete: true,
+    });
+    mockUseOnboarding.mockReturnValue(completeState);
+
+    render(<GettingStarted />);
+
+    expect(navigate).toHaveBeenCalledWith("/", { replace: true });
+  });
+
+  it("renders current step info and allows navigation to tutorial routes", async () => {
+    const state = buildOnboardingState({
+      completedSteps: [
+        { id: 99, route: "/completed" },
+      ],
+      currentStepInfo: { id: 1, route: "/projects", title: "Projects" },
+      nextStepInfo: { id: 3, route: "/calendar", title: "Calendar" },
+      currentStep: 2,
+    });
+    mockUseOnboarding.mockReturnValue(state);
+
+    render(<GettingStarted />);
+
+    const progress = screen.getByTestId("guided-progress");
+    expect(progress).toHaveAttribute(
+      "data-props",
+      expect.stringContaining('"currentValue":1')
+    );
+
+    const user = userEvent.setup();
+    const primaryButton = screen.getByRole("button", {
+      name: "onboarding.steps.step_1.button",
+    });
+    await user.click(primaryButton);
+
+    expect(navigate).toHaveBeenCalledWith("/projects?tutorial=true");
+
+    expect(screen.queryByTestId("sample-data-modal")).not.toBeInTheDocument();
+    const skipButton = screen.getByRole("button", {
+      name: "onboarding.getting_started.skip_setup",
+    });
+    await user.click(skipButton);
+    expect(screen.getByTestId("sample-data-modal")).toBeInTheDocument();
+
+    await user.click(screen.getByText("close-sample"));
+    await waitFor(() =>
+      expect(screen.queryByTestId("sample-data-modal")).not.toBeInTheDocument()
+    );
+  });
+
+  it("completes onboarding when finishing guided steps", async () => {
+    const completeOnboarding = jest.fn().mockResolvedValue(undefined);
+    const state = buildOnboardingState({
+      isAllStepsComplete: true,
+      completeOnboarding,
+    });
+    mockUseOnboarding.mockReturnValue(state);
+
+    render(<GettingStarted />);
+
+    const user = userEvent.setup();
+    const finishButton = screen.getByRole("button", {
+      name: "onboarding.getting_started.go_to_dashboard",
+    });
+
+    await user.click(finishButton);
+
+    await waitFor(() => expect(completeOnboarding).toHaveBeenCalledTimes(1));
+    expect(navigate).toHaveBeenCalledWith("/", { replace: true });
+  });
+});

--- a/src/pages/__tests__/Index.test.tsx
+++ b/src/pages/__tests__/Index.test.tsx
@@ -1,0 +1,109 @@
+import { act } from "react";
+import { render, screen } from "@/utils/testUtils";
+import Index from "../Index";
+import { supabase } from "@/integrations/supabase/client";
+import { useNavigate } from "react-router-dom";
+
+jest.mock("@/integrations/supabase/client", () => {
+  const onAuthStateChange = jest.fn();
+  const getSession = jest.fn();
+  return {
+    supabase: {
+      auth: {
+        onAuthStateChange,
+        getSession,
+      },
+    },
+  };
+});
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: jest.fn(),
+}));
+
+jest.mock("@/components/CrmDashboard", () => ({
+  __esModule: true,
+  default: () => <div data-testid="crm-dashboard" />,
+}));
+
+jest.mock("@/components/ui/loading-presets", () => ({
+  PageLoadingSkeleton: () => <div data-testid="page-loading" />,
+}));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const mockUseNavigate = useNavigate as jest.Mock;
+const mockAuth = supabase.auth as unknown as {
+  onAuthStateChange: jest.Mock;
+  getSession: jest.Mock;
+};
+
+describe("Index page", () => {
+  const navigate = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseNavigate.mockReturnValue(navigate);
+  });
+
+  it("shows loading skeleton while session is resolving", async () => {
+    let resolveSession: (value: any) => void = () => {};
+    mockAuth.onAuthStateChange.mockImplementation((_handler: any) => ({
+      data: { subscription: { unsubscribe: jest.fn() } },
+    }));
+    mockAuth.getSession.mockReturnValue(
+      new Promise((resolve) => {
+        resolveSession = resolve;
+      })
+    );
+
+    render(<Index />);
+
+    expect(screen.getByTestId("page-loading")).toBeInTheDocument();
+
+    await act(async () => {
+      resolveSession({ data: { session: null } });
+    });
+  });
+
+  it("renders dashboard when a user session exists", async () => {
+    mockAuth.onAuthStateChange.mockImplementation((_handler: any) => ({
+      data: { subscription: { unsubscribe: jest.fn() } },
+    }));
+    mockAuth.getSession.mockResolvedValue({
+      data: { session: { user: { id: "user-1" } } },
+    });
+
+    render(<Index />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId("crm-dashboard")).toBeInTheDocument();
+  });
+
+  it("renders marketing hero and navigates to auth when CTA clicked", async () => {
+    mockAuth.onAuthStateChange.mockImplementation((handler: any) => {
+      handler("SIGNED_OUT", null);
+      return { data: { subscription: { unsubscribe: jest.fn() } } };
+    });
+    mockAuth.getSession.mockResolvedValue({ data: { session: null } });
+
+    render(<Index />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const cta = screen.getByRole("button", { name: "buttons.get_started" });
+    cta.click();
+
+    expect(navigate).toHaveBeenCalledWith("/auth");
+  });
+});

--- a/src/pages/__tests__/NotFound.test.tsx
+++ b/src/pages/__tests__/NotFound.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@/utils/testUtils";
+import NotFound from "../NotFound";
+import { useLocation } from "react-router-dom";
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useLocation: jest.fn(),
+}));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const mockUseLocation = useLocation as jest.Mock;
+
+describe("NotFound page", () => {
+  const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseLocation.mockReturnValue({ pathname: "/missing" });
+  });
+
+  afterAll(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("logs the missing route and renders support link", () => {
+    render(<NotFound />);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "404 Error: User attempted to access non-existent route:",
+      "/missing"
+    );
+
+    expect(screen.getByText("errors.notFound.title")).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: "errors.notFound.cta" });
+    expect(link).toHaveAttribute("href", "/");
+  });
+});


### PR DESCRIPTION
## Summary
- add dedicated tests for SampleDataModal covering skip success/error and guided setup continuation
- cover the GettingStarted onboarding page interactions, including redirects, modal toggles, and completion flows
- verify the public Index landing page and NotFound route behaviors, and update unit-testing-plan.md progress snapshot

## Testing
- `npm test -- --runInBand src/components/__tests__/SampleDataModal.test.tsx src/pages/__tests__/GettingStarted.test.tsx src/pages/__tests__/Index.test.tsx src/pages/__tests__/NotFound.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68fd0677695c8321a0fcf8bf90f32326