### PR TITLE
Add coverage for error boundary, language switcher, and tooltip

### DIFF
--- a/docs/unit-testing-plan.md
+++ b/docs/unit-testing-plan.md
@@ -39,10 +39,10 @@
 | Core Libraries & Helpers | 13 | 13 | 100% |
 | Services & Data Access | 5 | 5 | 100% |
 | Contexts & Hooks | 27 | 27 | 100% |
-| UI Components & Pages | 53 | 70 | 76% |
-| UI Primitives & Shared Components | 17 | 17 | 100% |
+| UI Components & Pages | 56 | 73 | 77% |
+| UI Primitives & Shared Components | 18 | 18 | 100% |
 | Supabase Edge Functions & Automation | 9 | 9 | 100% |
-| **Overall** | **124** | **141** | **88%** |
+| **Overall** | **128** | **145** | **88%** |
 
 ### Core Libraries & Helpers
 | Area | File(s) | What to Cover | Priority | Status | Notes |
@@ -112,6 +112,9 @@
 | Global search | `src/components/GlobalSearch.tsx` | Debounced queries, status preload, keyboard navigation | High | Done | Covered by `src/components/__tests__/GlobalSearch.test.tsx` (debounce guard, preloaded statuses, keyboard selection). |
 | Protected route guard | `src/components/ProtectedRoute.tsx` | Auth gating, redirect logic, loading fallback | Medium | Done | Covered by `src/components/__tests__/ProtectedRoute.test.tsx` (loading/redirect + onboarding guard). |
 | Route prefetcher | `src/components/RoutePrefetcher.tsx` | Prefetch orchestration, duplicate avoidance | Medium | Done | Covered by `src/components/__tests__/RoutePrefetcher.test.tsx` (cache guard + Supabase prefetch). |
+| Error boundary | `src/components/ErrorBoundary.tsx` | Fallback rendering, copy-to-clipboard, custom fallback overrides | Medium | Done | Covered by `src/components/__tests__/ErrorBoundary.test.tsx` validating default UI, copy handling, and custom fallback support. |
+| Language switcher | `src/components/LanguageSwitcher.tsx` | Loading states, change handler promises, compact trigger variant | Low | Done | Covered by `src/components/__tests__/LanguageSwitcher.test.tsx` for loading disablement, async change flow, and compact badge display. |
+| Performance monitor instrumentation | `src/components/PerformanceMonitor.tsx` | Development-only gating, render-count warnings, metrics exposure | Low | Done | Covered by `src/components/__tests__/PerformanceMonitor.test.tsx` ensuring non-dev null rendering, warning threshold, and metrics helpers. |
 | Offline banner | `src/components/OfflineBanner.tsx` | Connectivity context integration, retry actions | Low | Done | Covered by `src/components/__tests__/OfflineBanner.test.tsx` (online skip + retry + spinner state). |
 | Auth page | `src/pages/Auth.tsx` | Sign-in/sign-up flows, password recovery, onboarding carousel toggles | High | Done | Covered by `src/pages/__tests__/Auth.test.tsx` for sign-in, sign-up, reset request, recovery update flows, and recovery entry guard. |
 | Lead detail page | `src/pages/LeadDetail.tsx` | Data loading, tab switching, error fallbacks | High | Done | Covered by `src/pages/__tests__/LeadDetail.test.tsx` for skeleton fallback, summary wiring, status actions, and fetch error toasts. |
@@ -180,6 +183,7 @@
 | Progress primitive wrapper | `src/components/ui/progress.tsx` | Value-to-transform mapping, default fallback state | Low | Done | Covered by `src/components/ui/__tests__/progress.test.tsx` ensuring default translate and value-driven offsets. |
 | Switch toggle | `src/components/ui/switch.tsx` | Data-state transitions, controlled toggles, accessibility attributes | Low | Done | Covered by `src/components/ui/__tests__/switch.test.tsx` asserting unchecked/checked transitions and controlled updates. |
 | Toast primitives | `src/components/ui/toast.tsx` | Viewport mounting, variant styling, close/action wiring | Medium | Done | Covered by `src/components/ui/__tests__/toast.test.tsx` confirming viewport class merge, destructive styling, and close attributes. |
+| Truncated text tooltip wrapper | `src/components/TruncatedTextWithTooltip.tsx` | Overflow detection, tooltip reveal, delay overrides | Low | Done | Covered by `src/components/__tests__/TruncatedTextWithTooltip.test.tsx` for empty text guard, non-truncated hover, and truncated tooltip display. |
 ### Supabase Edge Functions & Automation
 | Area | File(s) | What to Cover | Priority | Status | Notes |
 | --- | --- | --- | --- | --- | --- |
@@ -285,6 +289,7 @@ _Statuses_: `Not started`, `In progress`, `Blocked`, `Ready for review`, `Done`.
 | 2025-11-08 | Codex | Audited coverage against current repo state | Updated progress snapshot and backlog rows for onboarding, payments, admin, and remaining settings screens/components with no tests | Assign owners for new high-priority gaps |
 | 2025-11-09 | Codex | Added payments workspace hook coverage | `src/pages/payments/hooks/__tests__/usePaymentsData.test.ts`, `usePaymentsFilters.test.tsx`, and `usePaymentsTableColumns.test.tsx` lock Supabase pagination/search filters, draft thresholds, and column callbacks | Track future payments analytics or virtualization enhancements |
 | 2025-11-10 | Codex | Added onboarding landing coverage for remaining pages | Added `src/components/__tests__/SampleDataModal.test.tsx`, `src/pages/__tests__/GettingStarted.test.tsx`, `Index.test.tsx`, and `NotFound.test.tsx` to exercise modal flows, guided redirects, marketing CTA, and 404 logging | Next: extend coverage to Payments page, ReminderDetails page, and settings context usage |
+| 2025-11-11 | Codex | Added guard, language, and instrumentation component coverage | Added `src/components/__tests__/ErrorBoundary.test.tsx`, `LanguageSwitcher.test.tsx`, `PerformanceMonitor.test.tsx`, and `TruncatedTextWithTooltip.test.tsx` to lock fallback UI, language toggles, dev-only warnings, and truncation tooltips | Revisit when onboarding metrics expand or tooltip delays change |
 
 ## Maintenance Rules of Thumb
 - Treat this file like the single source of truth for unit testing status—update it in the same PR as any test additions or strategy changes.

--- a/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,123 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import ErrorBoundary from "../ErrorBoundary";
+
+jest.mock("react-i18next", () => ({
+  withTranslation: () =>
+    (Component: React.ComponentType<any>) =>
+      function WithTranslationWrapper(props: Record<string, unknown>) {
+        return (
+          <Component
+            {...props}
+            t={(key: string, options?: Record<string, string>) =>
+              options?.reference ? `${key}:${options.reference}` : key
+            }
+          />
+        );
+      },
+}));
+
+describe("ErrorBoundary", () => {
+  let consoleErrorSpy: jest.SpyInstance;
+  let originalClipboard: typeof navigator.clipboard;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    originalClipboard = navigator.clipboard;
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: jest.fn().mockResolvedValue(undefined),
+      },
+    });
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    Object.assign(navigator, { clipboard: originalClipboard });
+  });
+
+  it("renders children when no error occurs", () => {
+    render(
+      <ErrorBoundary>
+        <div data-testid="safe-child">Content</div>
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByTestId("safe-child")).toBeInTheDocument();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it("renders default fallback UI when an error is thrown", async () => {
+    const onError = jest.fn();
+
+    const ProblemChild = () => {
+      throw new Error("Boom");
+    };
+
+    render(
+      <ErrorBoundary onError={onError}>
+        <ProblemChild />
+      </ErrorBoundary>
+    );
+
+    expect(await screen.findByText("errorBoundary.title")).toBeInTheDocument();
+    expect(screen.getByText("Boom")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "buttons.tryAgain" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "buttons.reload" })).toBeInTheDocument();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("supports providing a custom fallback component", () => {
+    const ProblemChild = () => {
+      throw new Error("Boom");
+    };
+
+    render(
+      <ErrorBoundary fallback={<div data-testid="custom-fallback" />}> 
+        <ProblemChild />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByTestId("custom-fallback")).toBeInTheDocument();
+    expect(screen.queryByText("errorBoundary.title")).not.toBeInTheDocument();
+  });
+
+  it("copies error details to clipboard when requested", async () => {
+    const ProblemChild = () => {
+      throw new Error("Boom");
+    };
+
+    render(
+      <ErrorBoundary>
+        <ProblemChild />
+      </ErrorBoundary>
+    );
+
+    const copyButton = await screen.findByRole("button", { name: "buttons.copy" });
+    fireEvent.click(copyButton);
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        expect.stringContaining("Boom")
+      );
+    });
+  });
+
+  it("provides contextual summary for reference errors", async () => {
+    const ProblemChild = () => {
+      throw new ReferenceError("foo is not defined");
+    };
+
+    render(
+      <ErrorBoundary>
+        <ProblemChild />
+      </ErrorBoundary>
+    );
+
+    expect(
+      await screen.findByText("errorBoundary.missingReference:foo")
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/LanguageSwitcher.test.tsx
+++ b/src/components/__tests__/LanguageSwitcher.test.tsx
@@ -1,0 +1,105 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { LanguageSwitcher } from "../LanguageSwitcher";
+import { useLanguage } from "@/contexts/LanguageContext";
+
+jest.mock("@/contexts/LanguageContext", () => ({
+  useLanguage: jest.fn(),
+}));
+
+const mockUseLanguage = useLanguage as jest.MockedFunction<typeof useLanguage>;
+
+describe("LanguageSwitcher", () => {
+  beforeEach(() => {
+    mockUseLanguage.mockReset();
+  });
+
+  it("renders the current language label and switches languages", async () => {
+    const changeLanguage = jest.fn().mockResolvedValue(undefined);
+    mockUseLanguage.mockReturnValue({
+      currentLanguage: "en",
+      availableLanguages: [
+        { code: "en", native_name: "English", name: "English" },
+        { code: "tr", native_name: "Türkçe", name: "Turkish" },
+      ],
+      changeLanguage,
+      isLoading: false,
+    });
+
+    const user = userEvent.setup();
+    render(<LanguageSwitcher />);
+
+    const triggerButton = screen.getByRole("button", { name: /English/i });
+    expect(triggerButton).toBeEnabled();
+
+    await user.click(triggerButton);
+    await user.click(screen.getByText("Türkçe"));
+
+    expect(changeLanguage).toHaveBeenCalledWith("tr");
+  });
+
+  it("disables the trigger when languages are loading", () => {
+    mockUseLanguage.mockReturnValue({
+      currentLanguage: "en",
+      availableLanguages: [
+        { code: "en", native_name: "English", name: "English" },
+      ],
+      changeLanguage: jest.fn(),
+      isLoading: true,
+    });
+
+    render(<LanguageSwitcher />);
+
+    expect(screen.getByRole("button", { name: /English/i })).toBeDisabled();
+  });
+
+  it("disables the trigger while a language change is in progress", async () => {
+    let resolveChange: () => void = () => undefined;
+    const changeLanguage = jest.fn().mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveChange = resolve;
+        })
+    );
+
+    mockUseLanguage.mockReturnValue({
+      currentLanguage: "en",
+      availableLanguages: [
+        { code: "en", native_name: "English", name: "English" },
+        { code: "tr", native_name: "Türkçe", name: "Turkish" },
+      ],
+      changeLanguage,
+      isLoading: false,
+    });
+
+    const user = userEvent.setup();
+    render(<LanguageSwitcher />);
+
+    const triggerButton = screen.getByRole("button", { name: /English/i });
+    await user.click(triggerButton);
+    await user.click(screen.getByText("Türkçe"));
+
+    expect(changeLanguage).toHaveBeenCalledWith("tr");
+    expect(triggerButton).toBeDisabled();
+
+    resolveChange();
+    await waitFor(() => expect(triggerButton).toBeEnabled());
+  });
+
+  it("supports the compact variant", () => {
+    mockUseLanguage.mockReturnValue({
+      currentLanguage: "tr",
+      availableLanguages: [
+        { code: "en", native_name: "English", name: "English" },
+        { code: "tr", native_name: "Türkçe", name: "Turkish" },
+      ],
+      changeLanguage: jest.fn(),
+      isLoading: false,
+    });
+
+    render(<LanguageSwitcher variant="compact" />);
+
+    expect(screen.getByText("TR")).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/PerformanceMonitor.test.tsx
+++ b/src/components/__tests__/PerformanceMonitor.test.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { act, render } from "@testing-library/react";
+import { useOnboarding } from "@/contexts/OnboardingContext";
+
+jest.mock("@/contexts/OnboardingContext", () => ({
+  useOnboarding: jest.fn(),
+}));
+
+describe("PerformanceMonitor", () => {
+  const mockUseOnboarding = useOnboarding as jest.MockedFunction<typeof useOnboarding>;
+  const originalEnv = process.env.NODE_ENV;
+  let originalRAF: typeof window.requestAnimationFrame;
+  let originalCancelRAF: typeof window.cancelAnimationFrame;
+  let PerformanceMonitor: React.ComponentType;
+  let onboardingMetrics: any;
+
+  beforeAll(() => {
+    const previousEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "development";
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const module = require("../PerformanceMonitor");
+    PerformanceMonitor = module.PerformanceMonitor;
+    onboardingMetrics = (window as any).onboardingMetrics;
+    process.env.NODE_ENV = previousEnv;
+  });
+
+  beforeEach(() => {
+    mockUseOnboarding.mockReset();
+    originalRAF = window.requestAnimationFrame;
+    originalCancelRAF = window.cancelAnimationFrame;
+  });
+
+  afterEach(() => {
+    window.requestAnimationFrame = originalRAF;
+    window.cancelAnimationFrame = originalCancelRAF;
+    process.env.NODE_ENV = originalEnv;
+  });
+
+  it("returns null outside development mode", () => {
+    process.env.NODE_ENV = "test";
+    mockUseOnboarding.mockReturnValue({
+      stage: "intro",
+      currentStep: 0,
+      loading: false,
+    });
+
+    const { container } = render(<PerformanceMonitor />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("warns when rerender threshold exceeded in development", async () => {
+    process.env.NODE_ENV = "development";
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    let callIndex = 0;
+    mockUseOnboarding.mockImplementation(() => ({
+      stage: "setup",
+      currentStep: callIndex++,
+      loading: false,
+    }));
+
+    window.requestAnimationFrame = (callback: FrameRequestCallback) => {
+      callback(performance.now());
+      return 1 as unknown as number;
+    };
+    window.cancelAnimationFrame = jest.fn();
+
+    const { rerender } = render(<PerformanceMonitor />);
+
+    for (let i = 0; i < 105; i += 1) {
+      await act(async () => {
+        rerender(<PerformanceMonitor />);
+      });
+    }
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      "PerformanceMonitor: High onboarding re-render count detected:",
+      expect.objectContaining({
+        renderCount: expect.any(Number),
+        stage: "setup",
+        currentStep: expect.any(Number),
+        loading: false,
+        timestamp: expect.any(String),
+      })
+    );
+
+    expect(onboardingMetrics).toBeDefined();
+    await expect(onboardingMetrics?.getPerformanceStats()).resolves.toEqual({
+      message: "V3 Onboarding System - Production Ready",
+      databaseClean: true,
+      cacheOptimized: true,
+      consoleSpamRemoved: true,
+    });
+
+    warnSpy.mockRestore();
+  });
+});

--- a/src/components/__tests__/TruncatedTextWithTooltip.test.tsx
+++ b/src/components/__tests__/TruncatedTextWithTooltip.test.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TruncatedTextWithTooltip } from "../TruncatedTextWithTooltip";
+
+describe("TruncatedTextWithTooltip", () => {
+  let originalRAF: typeof window.requestAnimationFrame;
+  let originalCancelRAF: typeof window.cancelAnimationFrame;
+  let resizeObserverMock: jest.Mock;
+
+  beforeEach(() => {
+    originalRAF = window.requestAnimationFrame;
+    originalCancelRAF = window.cancelAnimationFrame;
+    resizeObserverMock = jest.fn().mockImplementation(() => ({
+      observe: jest.fn(),
+      disconnect: jest.fn(),
+    }));
+    (window as any).ResizeObserver = resizeObserverMock;
+  });
+
+  afterEach(() => {
+    window.requestAnimationFrame = originalRAF;
+    window.cancelAnimationFrame = originalCancelRAF;
+  });
+
+  it("returns null when no text provided", () => {
+    const { container } = render(<TruncatedTextWithTooltip text="" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("does not render tooltip content when text fits", async () => {
+    let frameCallback: FrameRequestCallback | null = null;
+    window.requestAnimationFrame = (callback: FrameRequestCallback) => {
+      frameCallback = callback;
+      return 1 as unknown as number;
+    };
+    window.cancelAnimationFrame = jest.fn();
+
+    const user = userEvent.setup();
+    render(<TruncatedTextWithTooltip text="Visible" delayDuration={0} />);
+
+    const textElement = screen.getByText("Visible");
+    Object.defineProperty(textElement, "scrollHeight", { value: 20, configurable: true });
+    Object.defineProperty(textElement, "clientHeight", { value: 20, configurable: true });
+    Object.defineProperty(textElement, "scrollWidth", { value: 20, configurable: true });
+    Object.defineProperty(textElement, "clientWidth", { value: 20, configurable: true });
+
+    await act(async () => {
+      frameCallback?.(performance.now());
+    });
+
+    await user.hover(textElement);
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Visible")).toHaveLength(1);
+    });
+  });
+
+  it("renders tooltip content when text is truncated", async () => {
+    let frameCallback: FrameRequestCallback | null = null;
+    window.requestAnimationFrame = (callback: FrameRequestCallback) => {
+      frameCallback = callback;
+      return 1 as unknown as number;
+    };
+    window.cancelAnimationFrame = jest.fn();
+
+    const user = userEvent.setup();
+    render(
+      <TruncatedTextWithTooltip
+        text="This is a very long piece of text"
+        lines={1}
+        delayDuration={0}
+      />
+    );
+
+    const textElement = screen.getByText("This is a very long piece of text");
+    Object.defineProperty(textElement, "scrollHeight", { value: 120, configurable: true });
+    Object.defineProperty(textElement, "clientHeight", { value: 20, configurable: true });
+    Object.defineProperty(textElement, "scrollWidth", { value: 200, configurable: true });
+    Object.defineProperty(textElement, "clientWidth", { value: 100, configurable: true });
+
+    await act(async () => {
+      frameCallback?.(performance.now());
+    });
+
+    await user.hover(textElement);
+
+    const occurrences = await screen.findAllByText("This is a very long piece of text");
+    expect(occurrences.length).toBeGreaterThan(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add focused Jest suites for the ErrorBoundary, LanguageSwitcher, PerformanceMonitor, and TruncatedTextWithTooltip components
- refresh docs/unit-testing-plan.md with the latest progress snapshot, target rows, and iteration log entry

## Testing
- npm test -- --runTestsByPath src/components/__tests__/ErrorBoundary.test.tsx src/components/__tests__/LanguageSwitcher.test.tsx src/components/__tests__/PerformanceMonitor.test.tsx src/components/__tests__/TruncatedTextWithTooltip.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68fd0a6b4d2483218942543a40ad00bb