### PR TITLE
Add unit tests for calendar components

### DIFF
--- a/docs/unit-testing-plan.md
+++ b/docs/unit-testing-plan.md
@@ -39,10 +39,10 @@
 | Core Libraries & Helpers | 13 | 13 | 100% |
 | Services & Data Access | 5 | 5 | 100% |
 | Contexts & Hooks | 27 | 27 | 100% |
-| UI Components & Pages | 61 | 73 | 84% |
+| UI Components & Pages | 67 | 73 | 92% |
 | UI Primitives & Shared Components | 18 | 18 | 100% |
 | Supabase Edge Functions & Automation | 9 | 9 | 100% |
-| **Overall** | **133** | **145** | **92%** |
+| **Overall** | **139** | **145** | **96%** |
 
 ### Core Libraries & Helpers
 | Area | File(s) | What to Cover | Priority | Status | Notes |
@@ -125,6 +125,12 @@
 | Workflows management page | `src/pages/Workflows.tsx` | Filtering, KPI summaries, pagination, toggle actions | High | Done | Covered by `src/pages/__tests__/Workflows.test.tsx` validating KPI summaries, segmented filters, pagination load-more, status toggles, edit wiring, and delete confirmation. |
 | Session detail page | `src/pages/SessionDetail.tsx` | Supabase fetch path, edit/delete flows, navigation fallback | High | Done | Covered by `src/pages/__tests__/SessionDetail.test.tsx` validating skeleton transition, delete fallback navigation, and load error toast. |
 | Calendar page | `src/pages/Calendar.tsx` | Range filters, session grouping, performance panels | High | Done | Covered by `src/pages/__tests__/Calendar.test.tsx` validating skeleton loading, segmented view switching, and session sheet launch. |
+| Calendar day grid cell | `src/components/calendar/CalendarDay.tsx` | Sorting, combined overflow counts, mobile day tap handling | Medium | Done | Covered by `src/components/calendar/__tests__/CalendarDay.test.tsx` ensuring formatted content, overflow messaging, and mobile callbacks. |
+| Calendar focused day view | `src/components/calendar/CalendarDayView.tsx` | Section counts, empty state messaging, touch gestures | Medium | Done | Covered by `src/components/calendar/__tests__/CalendarDayView.test.tsx` validating click handlers, empty fallback, and touch wiring. |
+| Calendar month view | `src/components/calendar/CalendarMonthView.tsx` | Multi-day aggregation, overflow tooltips, day navigation | Medium | Done | Covered by `src/components/calendar/__tests__/CalendarMonthView.test.tsx` confirming combined events, overflow indicators, and day click callback. |
+| Calendar week view | `src/components/calendar/CalendarWeek.tsx` | Time slot bucketing, mobile summary panels, timezone loading skeleton | High | Done | Covered by `src/components/calendar/__tests__/CalendarWeek.test.tsx` exercising loading skeleton, mobile rendering, and desktop grid callbacks. |
+| Calendar loading skeletons | `src/components/calendar/CalendarSkeleton.tsx` | Header counts, grid sizing, placeholder distribution | Low | Done | Covered by `src/components/calendar/__tests__/CalendarSkeleton.test.tsx` counting header cells, grid entries, and placeholder blocks. |
+| Calendar error boundary | `src/components/calendar/CalendarErrorBoundary.tsx` | Fallback UI, retry/reset behaviors, prop-based errors | Medium | Done | Covered by `src/components/calendar/__tests__/CalendarErrorBoundary.test.tsx` verifying thrown-error handling, retry wiring, and prop-controlled recovery. |
 | Upcoming sessions page | `src/pages/UpcomingSessions.tsx` | Filters, session sorting, empty state messaging | Medium | Done | Covered by `src/pages/__tests__/UpcomingSessions.test.tsx` confirming KPI metrics, segment filters, and session sheet navigation. |
 | Templates workspace | `src/pages/Templates.tsx` | Block editor integration, preview data toggles | Medium | Done | Covered by `src/pages/__tests__/Templates.test.tsx` exercising preview fallbacks, search empty states, row actions, and navigation flows. |
 | Settings services page | `src/pages/settings/Services.tsx` | Tutorial auto-start, section visibility, onboarding completion routing | Medium | Done | Covered by `src/pages/settings/__tests__/Services.test.tsx` verifying tutorial visibility, completion navigation, and exit handling. |
@@ -291,6 +297,7 @@ _Statuses_: `Not started`, `In progress`, `Blocked`, `Ready for review`, `Done`.
 | 2025-11-10 | Codex | Added onboarding landing coverage for remaining pages | Added `src/components/__tests__/SampleDataModal.test.tsx`, `src/pages/__tests__/GettingStarted.test.tsx`, `Index.test.tsx`, and `NotFound.test.tsx` to exercise modal flows, guided redirects, marketing CTA, and 404 logging | Next: extend coverage to Payments page, ReminderDetails page, and settings context usage |
 | 2025-11-11 | Codex | Added guard, language, and instrumentation component coverage | Added `src/components/__tests__/ErrorBoundary.test.tsx`, `LanguageSwitcher.test.tsx`, `PerformanceMonitor.test.tsx`, and `TruncatedTextWithTooltip.test.tsx` to lock fallback UI, language toggles, dev-only warnings, and truncation tooltips | Revisit when onboarding metrics expand or tooltip delays change |
 | 2025-11-12 | Codex | Added Payments workspace page + component coverage | Added `src/pages/__tests__/Payments.test.tsx` alongside component specs for date controls, trend chart, metrics summary, and table section to verify filter resets, export flows, formatter output, and chart/empty states | Next: extend coverage to ReminderDetails page and remaining settings screens |
+| 2025-11-13 | Codex | Added calendar component coverage | Added `src/components/calendar/__tests__/CalendarDay.test.tsx`, `CalendarDayView.test.tsx`, `CalendarMonthView.test.tsx`, `CalendarWeek.test.tsx`, `CalendarSkeleton.test.tsx`, and `CalendarErrorBoundary.test.tsx` to cover mobile/day/month/week interactions, skeleton scaffolds, and error recovery flows | Next: Explore coverage for calendar virtualization performance metrics and touch gesture edge cases |
 
 ## Maintenance Rules of Thumb
 - Treat this file like the single source of truth for unit testing status—update it in the same PR as any test additions or strategy changes.

--- a/src/components/calendar/__tests__/CalendarDay.test.tsx
+++ b/src/components/calendar/__tests__/CalendarDay.test.tsx
@@ -1,0 +1,152 @@
+import { fireEvent, render, screen } from "@/utils/testUtils";
+import { CalendarDay } from "../CalendarDay";
+
+jest.mock("@/lib/utils", () => ({
+  ...(jest.requireActual("@/lib/utils") as Record<string, unknown>),
+  formatTime: jest.fn((value: string) => `formatted-${value}`),
+  getUserLocale: jest.fn(() => "en-US"),
+}));
+
+describe("CalendarDay", () => {
+  const baseDate = new Date("2024-05-15T00:00:00Z");
+  const currentDate = new Date("2024-05-01T00:00:00Z");
+  const onSessionClick = jest.fn();
+  const onActivityClick = jest.fn();
+  const onDayClick = jest.fn();
+
+  const leadsMap = {
+    "lead-1": { id: "lead-1", name: "Alice" },
+    "lead-2": { id: "lead-2", name: "Bob" },
+  };
+
+  const projectsMap = {
+    "project-1": { id: "project-1", name: "Wedding", lead_id: "lead-1" },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    onSessionClick.mockClear();
+    onActivityClick.mockClear();
+    onDayClick.mockClear();
+  });
+
+  it("renders sessions and activities for the selected day", () => {
+    render(
+      <CalendarDay
+        date={baseDate}
+        currentDate={currentDate}
+        sessions={[
+          {
+            id: "session-1",
+            session_date: "2024-05-15",
+            session_time: "09:00",
+            status: "scheduled",
+            lead_id: "lead-1",
+            project_id: "project-1",
+          },
+        ]}
+        activities={[
+          {
+            id: "activity-1",
+            content: "Call bride",
+            reminder_date: "2024-05-15",
+            reminder_time: "08:30",
+            type: "call",
+            lead_id: "lead-2",
+            project_id: null,
+            completed: false,
+          },
+        ]}
+        showSessions
+        showReminders
+        leadsMap={leadsMap}
+        projectsMap={projectsMap}
+        isMobile={false}
+        onSessionClick={onSessionClick}
+        onActivityClick={onActivityClick}
+      />
+    );
+
+    expect(screen.getByText("formatted-09:00 • Alice")).toBeInTheDocument();
+    expect(screen.getByText("formatted-08:30 • Bob")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("formatted-09:00 • Alice"));
+    expect(onSessionClick).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "session-1" })
+    );
+
+    fireEvent.click(screen.getByText("formatted-08:30 • Bob"));
+    expect(onActivityClick).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "activity-1" })
+    );
+  });
+
+  it("shows overflow indicator when more than two events exist", () => {
+    render(
+      <CalendarDay
+        date={baseDate}
+        currentDate={currentDate}
+        sessions={[
+          {
+            id: "session-1",
+            session_date: "2024-05-15",
+            session_time: "09:00",
+            status: "scheduled",
+            lead_id: "lead-1",
+            project_id: "project-1",
+          },
+          {
+            id: "session-2",
+            session_date: "2024-05-15",
+            session_time: "10:00",
+            status: "scheduled",
+            lead_id: "lead-1",
+            project_id: "project-1",
+          },
+        ]}
+        activities={[
+          {
+            id: "activity-1",
+            content: "Send invoice",
+            reminder_date: "2024-05-15",
+            reminder_time: "11:00",
+            type: "todo",
+            lead_id: "lead-2",
+            project_id: null,
+          },
+        ]}
+        showSessions
+        showReminders
+        leadsMap={leadsMap}
+        projectsMap={projectsMap}
+        isMobile={false}
+        onSessionClick={onSessionClick}
+        onActivityClick={onActivityClick}
+      />
+    );
+
+    expect(screen.getByText("+1 more")).toBeInTheDocument();
+  });
+
+  it("invokes day click callback on mobile", () => {
+    render(
+      <CalendarDay
+        date={baseDate}
+        currentDate={currentDate}
+        sessions={[]}
+        activities={[]}
+        showSessions={false}
+        showReminders={false}
+        leadsMap={{}}
+        projectsMap={{}}
+        isMobile
+        onSessionClick={onSessionClick}
+        onActivityClick={onActivityClick}
+        onDayClick={onDayClick}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+    expect(onDayClick).toHaveBeenCalledWith(baseDate);
+  });
+});

--- a/src/components/calendar/__tests__/CalendarDayView.test.tsx
+++ b/src/components/calendar/__tests__/CalendarDayView.test.tsx
@@ -1,0 +1,165 @@
+import { fireEvent, render, screen } from "@/utils/testUtils";
+import { CalendarDayView } from "../CalendarDayView";
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) =>
+      options?.count != null ? `${key}:${options.count}` : key,
+  }),
+}));
+
+jest.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock("@/components/ui/badge", () => ({
+  Badge: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock("@/lib/utils", () => ({
+  ...(jest.requireActual("@/lib/utils") as Record<string, unknown>),
+  getUserLocale: jest.fn(() => "en-US"),
+  formatTime: jest.fn((value: string) => `formatted-${value}`),
+  formatDate: jest.fn((value: string) => `formatted-date-${value}`),
+}));
+
+const mockUseOrganizationTimezone = jest.fn(() => ({
+  formatTime: (value: string) => `org-${value}`,
+}));
+
+jest.mock("@/hooks/useOrganizationTimezone", () => ({
+  useOrganizationTimezone: () => mockUseOrganizationTimezone(),
+}));
+
+describe("CalendarDayView", () => {
+  const baseDate = new Date("2024-05-15T00:00:00Z");
+  const touchHandlers = {
+    handleTouchStart: jest.fn(),
+    handleTouchMove: jest.fn(),
+    handleTouchEnd: jest.fn(),
+    handleTouchCancel: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.values(touchHandlers).forEach((handler) => handler.mockClear());
+  });
+
+  it("renders sessions and reminders with click handlers", () => {
+    const onSessionClick = jest.fn();
+    const onActivityClick = jest.fn();
+
+    render(
+      <CalendarDayView
+        currentDate={baseDate}
+        getEventsForDate={() => ({
+          sessions: [
+            {
+              id: "session-1",
+              session_date: "2024-05-15",
+              session_time: "09:00",
+              status: "scheduled",
+              notes: "Bring contract",
+              lead_id: "lead-1",
+              project_id: "project-1",
+            },
+          ],
+          activities: [
+            {
+              id: "activity-1",
+              content: "Call bride",
+              reminder_date: "2024-05-15",
+              reminder_time: "08:30",
+              type: "call",
+              lead_id: "lead-2",
+              project_id: null,
+            },
+          ],
+        })}
+        showSessions
+        showReminders
+        leadsMap={{
+          "lead-1": { name: "Alice" },
+          "lead-2": { name: "Bob" },
+        }}
+        projectsMap={{
+          "project-1": { name: "Wedding" },
+        }}
+        onSessionClick={onSessionClick}
+        onActivityClick={onActivityClick}
+        touchHandlers={touchHandlers}
+      />
+    );
+
+    expect(
+      screen.getByText((content) => content.includes("calendar.sections.sessions"))
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText((content) => content.includes("calendar.sections.reminders"))
+    ).toBeInTheDocument();
+    expect(screen.getByText("org-09:00")).toBeInTheDocument();
+    expect(screen.getByText("org-08:30")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("org-09:00"));
+    expect(onSessionClick).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "session-1" })
+    );
+
+    fireEvent.click(screen.getByText("Call bride"));
+    expect(onActivityClick).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "activity-1" })
+    );
+  });
+
+  it("renders empty state when filters disable all sections", () => {
+    render(
+      <CalendarDayView
+        currentDate={baseDate}
+        getEventsForDate={() => ({ sessions: [], activities: [] })}
+        showSessions={false}
+        showReminders={false}
+        leadsMap={{}}
+        projectsMap={{}}
+        onSessionClick={jest.fn()}
+        onActivityClick={jest.fn()}
+        touchHandlers={touchHandlers}
+      />
+    );
+
+    expect(screen.getByText("calendar.emptyStates.noEvents")).toBeInTheDocument();
+    expect(screen.getByText("calendar.emptyStates.enableFilters")).toBeInTheDocument();
+  });
+
+  it("wires touch handlers for gesture navigation", () => {
+    render(
+      <CalendarDayView
+        currentDate={baseDate}
+        getEventsForDate={() => ({ sessions: [], activities: [] })}
+        showSessions={false}
+        showReminders={false}
+        leadsMap={{}}
+        projectsMap={{}}
+        onSessionClick={jest.fn()}
+        onActivityClick={jest.fn()}
+        touchHandlers={touchHandlers}
+      />
+    );
+
+    const container = screen.getByText("calendar.emptyStates.noEvents").parentElement?.parentElement;
+    expect(container).toBeTruthy();
+
+    if (container) {
+      fireEvent.touchStart(container, { touches: [] });
+      fireEvent.touchMove(container, { touches: [] });
+      fireEvent.touchEnd(container, { changedTouches: [] });
+      fireEvent.touchCancel(container);
+    }
+
+    expect(touchHandlers.handleTouchStart).toHaveBeenCalled();
+    expect(touchHandlers.handleTouchMove).toHaveBeenCalled();
+    expect(touchHandlers.handleTouchEnd).toHaveBeenCalled();
+    expect(touchHandlers.handleTouchCancel).toHaveBeenCalled();
+  });
+});

--- a/src/components/calendar/__tests__/CalendarErrorBoundary.test.tsx
+++ b/src/components/calendar/__tests__/CalendarErrorBoundary.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render, screen } from "@/utils/testUtils";
+import { CalendarErrorBoundary, CalendarErrorWrapper } from "../CalendarErrorBoundary";
+
+describe("CalendarErrorBoundary", () => {
+  const originalEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    process.env.NODE_ENV = "test";
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv;
+    jest.restoreAllMocks();
+  });
+
+  it("renders fallback UI when a child throws and supports retry", () => {
+    const retry = jest.fn();
+    const Thrower = () => {
+      throw new Error("calendar failed");
+    };
+
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
+
+    render(
+      <CalendarErrorBoundary retry={retry}>
+        <Thrower />
+      </CalendarErrorBoundary>
+    );
+
+    expect(screen.getByText("Calendar Load Failed")).toBeInTheDocument();
+    expect(screen.queryByText("Error Details")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Retry"));
+    expect(retry).toHaveBeenCalled();
+
+    expect(screen.getByText("Refresh Page")).toBeInTheDocument();
+
+    consoleSpy.mockRestore();
+  });
+
+  it("uses provided error prop and hides fallback when cleared", () => {
+    const { rerender } = render(
+      <CalendarErrorWrapper error={new Error("from hook")}>
+        <div>child</div>
+      </CalendarErrorWrapper>
+    );
+
+    expect(screen.getByText("Calendar Load Failed")).toBeInTheDocument();
+
+    rerender(
+      <CalendarErrorWrapper error={null}>
+        <div>child</div>
+      </CalendarErrorWrapper>
+    );
+
+    expect(screen.queryByText("Calendar Load Failed")).not.toBeInTheDocument();
+    expect(screen.getByText("child")).toBeInTheDocument();
+  });
+});

--- a/src/components/calendar/__tests__/CalendarMonthView.test.tsx
+++ b/src/components/calendar/__tests__/CalendarMonthView.test.tsx
@@ -1,0 +1,175 @@
+import { fireEvent, render, screen, within } from "@/utils/testUtils";
+import { CalendarMonthView } from "../CalendarMonthView";
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) =>
+      options?.count != null ? `${key}:${options.count}` : key,
+  }),
+}));
+
+jest.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock("@/lib/utils", () => ({
+  ...(jest.requireActual("@/lib/utils") as Record<string, unknown>),
+  getUserLocale: jest.fn(() => "en-US"),
+  getDateFnsLocale: jest.fn(() => undefined),
+  formatTime: jest.fn((value: string) => `formatted-${value}`),
+  formatDate: jest.fn((value: string) => `formatted-date-${value}`),
+}));
+
+describe("CalendarMonthView", () => {
+  const currentDate = new Date("2024-05-15T00:00:00Z");
+  const session = {
+    id: "session-1",
+    session_date: "2024-05-15",
+    session_time: "09:00",
+    status: "scheduled",
+    lead_id: "lead-1",
+    project_id: "project-1",
+    notes: "Bring contract",
+  };
+  const activity = {
+    id: "activity-1",
+    content: "Send invoice",
+    reminder_date: "2024-05-15",
+    reminder_time: "10:00",
+    type: "call",
+    lead_id: "lead-2",
+    project_id: null,
+    completed: false,
+  };
+
+  const getEventsForDate = jest.fn((date: Date) => {
+    const key = date.toISOString().slice(0, 10);
+    if (key === "2024-05-15") {
+      return { sessions: [session], activities: [activity] };
+    }
+    if (key === "2024-05-16") {
+      return {
+        sessions: [
+          { ...session, id: "session-2", session_time: "11:00" },
+          { ...session, id: "session-3", session_time: "12:00" },
+        ],
+        activities: [activity],
+      };
+    }
+    return { sessions: [], activities: [] };
+  });
+
+  const leadsMap = {
+    "lead-1": { name: "Alice" },
+    "lead-2": { name: "Bob" },
+  };
+  const projectsMap = {
+    "project-1": { name: "Wedding" },
+  };
+
+  beforeEach(() => {
+    getEventsForDate.mockClear();
+  });
+
+  it("renders events for the active month and handles clicks", () => {
+    const onSessionClick = jest.fn();
+    const onActivityClick = jest.fn();
+
+    render(
+      <CalendarMonthView
+        currentDate={currentDate}
+        getEventsForDate={getEventsForDate}
+        showSessions
+        showReminders
+        leadsMap={leadsMap}
+        projectsMap={projectsMap}
+        onSessionClick={onSessionClick}
+        onActivityClick={onActivityClick}
+        touchHandlers={{
+          handleTouchStart: jest.fn(),
+          handleTouchMove: jest.fn(),
+          handleTouchEnd: jest.fn(),
+          handleTouchCancel: jest.fn(),
+        }}
+      />
+    );
+
+    const sessionButton = screen
+      .getByText(/formatted-09:00 Alice/i)
+      .closest("button");
+    expect(sessionButton).toBeTruthy();
+    fireEvent.click(sessionButton!);
+    expect(onSessionClick).toHaveBeenCalledWith(expect.objectContaining({ id: "session-1" }));
+
+    const activityButton = screen
+      .getByText(/formatted-10:00 Bob/i)
+      .closest("button");
+    expect(activityButton).toBeTruthy();
+    fireEvent.click(activityButton!);
+    expect(onActivityClick).toHaveBeenCalledWith(expect.objectContaining({ id: "activity-1" }));
+  });
+
+  it("shows overflow tooltip indicator when more events exist", () => {
+    render(
+      <CalendarMonthView
+        currentDate={currentDate}
+        getEventsForDate={getEventsForDate}
+        showSessions
+        showReminders
+        leadsMap={leadsMap}
+        projectsMap={projectsMap}
+        onSessionClick={jest.fn()}
+        onActivityClick={jest.fn()}
+        onDayClick={jest.fn()}
+        touchHandlers={{
+          handleTouchStart: jest.fn(),
+          handleTouchMove: jest.fn(),
+          handleTouchEnd: jest.fn(),
+          handleTouchCancel: jest.fn(),
+        }}
+      />
+    );
+
+    const overflowText = screen.getByText("calendar.labels.moreEvents:1");
+    expect(overflowText).toBeInTheDocument();
+  });
+
+  it("invokes day click callback when provided", () => {
+    const onDayClick = jest.fn();
+
+    render(
+      <CalendarMonthView
+        currentDate={currentDate}
+        getEventsForDate={getEventsForDate}
+        showSessions
+        showReminders
+        leadsMap={leadsMap}
+        projectsMap={projectsMap}
+        onSessionClick={jest.fn()}
+        onActivityClick={jest.fn()}
+        onDayClick={onDayClick}
+        touchHandlers={{
+          handleTouchStart: jest.fn(),
+          handleTouchMove: jest.fn(),
+          handleTouchEnd: jest.fn(),
+          handleTouchCancel: jest.fn(),
+        }}
+      />
+    );
+
+    const maySixteenthCell = screen.getAllByText("16").find((node) => {
+      const button = node.closest("button");
+      if (!button) return false;
+      return within(button).queryByText(/formatted-11:00 Alice/i) !== null;
+    });
+
+    expect(maySixteenthCell).toBeTruthy();
+    if (maySixteenthCell) {
+      fireEvent.click(maySixteenthCell.closest("button")!);
+    }
+
+    expect(onDayClick).toHaveBeenCalled();
+  });
+});

--- a/src/components/calendar/__tests__/CalendarSkeleton.test.tsx
+++ b/src/components/calendar/__tests__/CalendarSkeleton.test.tsx
@@ -1,0 +1,36 @@
+import { render } from "@/utils/testUtils";
+import { CalendarDaySkeleton, CalendarSkeleton, CalendarWeekSkeleton } from "../CalendarSkeleton";
+
+describe("Calendar skeletons", () => {
+  let randomSpy: jest.SpyInstance<number, []>;
+
+  beforeAll(() => {
+    randomSpy = jest.spyOn(Math, "random").mockReturnValue(0.9);
+  });
+
+  afterAll(() => {
+    randomSpy.mockRestore();
+  });
+
+  it("renders month skeleton with seven weekday headers and 42 day cells", () => {
+    const { container } = render(<CalendarSkeleton />);
+    const header = container.querySelector(".grid.grid-cols-7");
+    expect(header?.children).toHaveLength(7);
+
+    const dayGrid = container.querySelector(".grid.grid-cols-7.gap-px");
+    expect(dayGrid?.children).toHaveLength(42);
+  });
+
+  it("renders week skeleton with header and time slot rows", () => {
+    const { container } = render(<CalendarWeekSkeleton />);
+    const headers = container.querySelectorAll(".grid.grid-cols-8");
+    // One header row plus sixteen time-slot rows
+    expect(headers.length).toBeGreaterThan(1);
+  });
+
+  it("renders day skeleton with session and reminder placeholders", () => {
+    const { container } = render(<CalendarDaySkeleton />);
+    expect(container.querySelectorAll(".h-16")).toHaveLength(3);
+    expect(container.querySelectorAll(".h-12")).toHaveLength(2);
+  });
+});

--- a/src/components/calendar/__tests__/CalendarWeek.test.tsx
+++ b/src/components/calendar/__tests__/CalendarWeek.test.tsx
@@ -1,0 +1,173 @@
+import { fireEvent, render, screen } from "@/utils/testUtils";
+import { CalendarWeek } from "../CalendarWeek";
+
+const actualUtils = jest.requireActual("@/lib/utils");
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) =>
+      options?.count != null ? `${key}:${options.count}` : key,
+  }),
+}));
+
+jest.mock("@/lib/utils", () => ({
+  ...(jest.requireActual("@/lib/utils") as Record<string, unknown>),
+  getUserLocale: jest.fn(() => "en-US"),
+  getStartOfWeek: jest.fn((date: Date) => actualUtils.getStartOfWeek(date, "en-US")),
+  getDateFnsLocale: jest.fn(() => undefined),
+  formatTime: jest.fn((value: string) => `formatted-${value}`),
+}));
+
+const mockUseSmartTimeRange = jest.fn();
+
+jest.mock("@/hooks/useSmartTimeRange", () => ({
+  useSmartTimeRange: () => mockUseSmartTimeRange(),
+}));
+
+const mockUseOrganizationTimezone = jest.fn();
+
+jest.mock("@/hooks/useOrganizationTimezone", () => ({
+  useOrganizationTimezone: () => mockUseOrganizationTimezone(),
+}));
+
+describe("CalendarWeek", () => {
+  const currentDate = new Date("2024-05-15T00:00:00Z");
+  const sessions = [
+    {
+      id: "session-1",
+      session_date: "2024-05-15",
+      session_time: "09:00",
+      status: "scheduled",
+      lead_id: "lead-1",
+      project_id: "project-1",
+      notes: "Bring contract",
+    },
+  ];
+  const activities = [
+    {
+      id: "activity-1",
+      content: "Send invoice",
+      reminder_date: "2024-05-15",
+      reminder_time: "10:00",
+      type: "call",
+      lead_id: "lead-2",
+      project_id: null,
+      completed: false,
+    },
+  ];
+  const leadsMap = {
+    "lead-1": { id: "lead-1", name: "Alice" },
+    "lead-2": { id: "lead-2", name: "Bob" },
+  };
+  const projectsMap = {
+    "project-1": { id: "project-1", name: "Wedding", lead_id: "lead-1" },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseSmartTimeRange.mockReturnValue({
+      timeSlots: [
+        { hour: 9, minute: 0, display: "09:00" },
+        { hour: 10, minute: 0, display: "10:00" },
+      ],
+      getSlotIndex: jest.fn(() => 0),
+    });
+    mockUseOrganizationTimezone.mockReturnValue({
+      formatTime: (value: string) => `org-${value}`,
+      loading: false,
+    });
+  });
+
+  it("renders a loading skeleton while timezone data loads", () => {
+    mockUseOrganizationTimezone.mockReturnValue({
+      formatTime: (value: string) => `org-${value}`,
+      loading: true,
+    });
+
+    const { container } = render(
+      <CalendarWeek
+        currentDate={currentDate}
+        sessions={sessions}
+        activities={activities}
+        showSessions
+        showReminders
+        leadsMap={leadsMap}
+        projectsMap={projectsMap}
+        isMobile={false}
+        getEventsForDate={() => ({ sessions, activities })}
+        onSessionClick={jest.fn()}
+        onActivityClick={jest.fn()}
+      />
+    );
+
+    expect(container.querySelectorAll(".animate-pulse").length).toBeGreaterThan(0);
+  });
+
+  it("renders mobile day summary with interactions", () => {
+    const onSessionClick = jest.fn();
+    const onActivityClick = jest.fn();
+    const onDayClick = jest.fn();
+
+    render(
+      <CalendarWeek
+        currentDate={currentDate}
+        sessions={sessions}
+        activities={activities}
+        showSessions
+        showReminders
+        leadsMap={leadsMap}
+        projectsMap={projectsMap}
+        isMobile
+        getEventsForDate={() => ({ sessions, activities })}
+        onSessionClick={onSessionClick}
+        onActivityClick={onActivityClick}
+        onDayClick={onDayClick}
+      />
+    );
+
+    expect(screen.getByText("calendar.sections.sessions:1")).toBeInTheDocument();
+    expect(screen.getByText("calendar.sections.reminders:1")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("org-09:00"));
+    expect(onSessionClick).toHaveBeenCalledWith(expect.objectContaining({ id: "session-1" }));
+
+    fireEvent.click(screen.getByText("Send invoice"));
+    expect(onActivityClick).toHaveBeenCalledWith(expect.objectContaining({ id: "activity-1" }));
+
+    const dayButton = screen
+      .getAllByRole("button")
+      .find((button) => button.textContent?.includes("15"));
+    expect(dayButton).toBeTruthy();
+    fireEvent.click(dayButton!);
+    expect(onDayClick).toHaveBeenCalled();
+  });
+
+  it("renders desktop grid and wires event callbacks", () => {
+    const onSessionClick = jest.fn();
+    const onActivityClick = jest.fn();
+
+    render(
+      <CalendarWeek
+        currentDate={currentDate}
+        sessions={sessions}
+        activities={activities}
+        showSessions
+        showReminders
+        leadsMap={leadsMap}
+        projectsMap={projectsMap}
+        isMobile={false}
+        getEventsForDate={() => ({ sessions, activities })}
+        onSessionClick={onSessionClick}
+        onActivityClick={onActivityClick}
+      />
+    );
+
+    const sessionButton = screen.getAllByRole("button", { name: /Alice/ })[0];
+    fireEvent.click(sessionButton);
+    expect(onSessionClick).toHaveBeenCalledWith(expect.objectContaining({ id: "session-1" }));
+
+    const activityButton = screen.getAllByRole("button", { name: /Bob/ })[0];
+    fireEvent.click(activityButton);
+    expect(onActivityClick).toHaveBeenCalledWith(expect.objectContaining({ id: "activity-1" }));
+  });
+});


### PR DESCRIPTION
## Summary
- add targeted test suites for CalendarDay, CalendarDayView, CalendarMonthView, CalendarWeek, CalendarSkeleton, and CalendarErrorBoundary components
- verify event click handlers, overflow indicators, error fallback, and skeleton layout behaviours across mobile and desktop flows
- document new coverage in docs/unit-testing-plan.md with progress snapshot and iteration log updates

## Testing
- `npm test -- src/components/calendar/__tests__/CalendarDay.test.tsx --runInBand`
- `npm test -- src/components/calendar/__tests__/CalendarDayView.test.tsx --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68fd0fc8b650832194ae2037fbe4cfe3