### PR TITLE
Add tests for reminder details page coverage

### DIFF
--- a/docs/unit-testing-plan.md
+++ b/docs/unit-testing-plan.md
@@ -39,10 +39,10 @@
 | Core Libraries & Helpers | 13 | 13 | 100% |
 | Services & Data Access | 5 | 5 | 100% |
 | Contexts & Hooks | 27 | 27 | 100% |
-| UI Components & Pages | 70 | 73 | 96% |
+| UI Components & Pages | 71 | 73 | 97% |
 | UI Primitives & Shared Components | 18 | 18 | 100% |
 | Supabase Edge Functions & Automation | 9 | 9 | 100% |
-| **Overall** | **142** | **145** | **98%** |
+| **Overall** | **143** | **145** | **99%** |
 
 ### Core Libraries & Helpers
 | Area | File(s) | What to Cover | Priority | Status | Notes |
@@ -163,7 +163,7 @@
 | Marketing landing page | `src/pages/Index.tsx` | Auth-based redirects, CTA links, feature highlights | Medium | Done | Covered by `src/pages/__tests__/Index.test.tsx` validating loading skeleton, CRM redirect, and public CTA navigation. |
 | Not found route | `src/pages/NotFound.tsx` | Support links, navigation back to dashboard, localization | Low | Done | Covered by `src/pages/__tests__/NotFound.test.tsx` asserting error logging and dashboard link rendering. |
 | Payments dashboard page | `src/pages/Payments.tsx` | Metrics cards, filters, pagination, workspace toggles | High | Done | Covered by `src/pages/__tests__/Payments.test.tsx` validating filter state wiring, export workbook creation, toast feedback, and table/search props. |
-| Reminder details page | `src/pages/ReminderDetails.tsx` | Reminder fetch, status updates, reschedule/cancel flows | High | Not started | Lacks tests for Supabase-driven reminder lifecycle; add success/error scenarios. |
+| Reminder details page | `src/pages/ReminderDetails.tsx` | Reminder fetch, status updates, reschedule/cancel flows | High | Done | Covered by `src/pages/__tests__/ReminderDetails.test.tsx` exercising fetch stats, error toasts, completion toggles, and project dialog hand-offs. |
 | Template builder page | `src/pages/TemplateBuilder.tsx` | Editor state management, autosave/publish, preview toggles | High | Done | Covered by `src/pages/__tests__/TemplateBuilder.test.tsx` for loading state, save workflow, and block updates. |
 | Admin console screens | `src/pages/admin/Users.tsx`, `Localization.tsx`, `System.tsx` | Table interactions, role actions, localization sync | High | Done | Covered by `src/pages/admin/__tests__/Users.test.tsx`, `Localization.test.tsx`, and `System.test.tsx` rendering translation scaffolding and toggle interactions. |
 | Settings management pages | `src/pages/settings/Billing.tsx`, `Contracts.tsx`, `Leads.tsx`, `Profile.tsx`, `Account_old.tsx` | Section visibility, save flows, permission guards | Medium | Done | Covered by new suites in `src/pages/settings/__tests__/Billing.test.tsx`, `Contracts.test.tsx`, `Leads.test.tsx`, `Profile.test.tsx`, and `Account_old.test.tsx` validating headers, loading guards, and working-hour updates. |
@@ -298,6 +298,7 @@ _Statuses_: `Not started`, `In progress`, `Blocked`, `Ready for review`, `Done`.
 | 2025-11-11 | Codex | Added guard, language, and instrumentation component coverage | Added `src/components/__tests__/ErrorBoundary.test.tsx`, `LanguageSwitcher.test.tsx`, `PerformanceMonitor.test.tsx`, and `TruncatedTextWithTooltip.test.tsx` to lock fallback UI, language toggles, dev-only warnings, and truncation tooltips | Revisit when onboarding metrics expand or tooltip delays change |
 | 2025-11-12 | Codex | Added Payments workspace page + component coverage | Added `src/pages/__tests__/Payments.test.tsx` alongside component specs for date controls, trend chart, metrics summary, and table section to verify filter resets, export flows, formatter output, and chart/empty states | Next: extend coverage to ReminderDetails page and remaining settings screens |
 | 2025-11-13 | Codex | Added calendar component coverage | Added `src/components/calendar/__tests__/CalendarDay.test.tsx`, `CalendarDayView.test.tsx`, `CalendarMonthView.test.tsx`, `CalendarWeek.test.tsx`, `CalendarSkeleton.test.tsx`, and `CalendarErrorBoundary.test.tsx` to cover mobile/day/month/week interactions, skeleton scaffolds, and error recovery flows | Next: Explore coverage for calendar virtualization performance metrics and touch gesture edge cases |
+| 2025-11-14 | Codex | Added reminder details page coverage | Added `src/pages/__tests__/ReminderDetails.test.tsx` to validate reminder stats, fetch error toasts, completion toggles, navigation, and project dialog fetches | Keep an eye on future reminder reschedule flows or provider refactors |
 
 ## Maintenance Rules of Thumb
 - Treat this file like the single source of truth for unit testing status—update it in the same PR as any test additions or strategy changes.

--- a/src/pages/__tests__/ReminderDetails.test.tsx
+++ b/src/pages/__tests__/ReminderDetails.test.tsx
@@ -1,0 +1,475 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@/utils/testUtils";
+import ReminderDetails from "../ReminderDetails";
+import { toast } from "@/hooks/use-toast";
+import { supabase } from "@/integrations/supabase/client";
+
+const mockNavigate = jest.fn();
+
+jest.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    from: jest.fn(),
+  },
+}));
+
+type TranslationOptions = { [key: string]: any };
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: TranslationOptions) => {
+      if (options?.returnObjects) {
+        return [];
+      }
+      if (options?.count !== undefined) {
+        return `${key}:${options.count}`;
+      }
+      if (options?.tomorrow !== undefined || options?.later !== undefined) {
+        return `${key}:${options?.tomorrow ?? 0}/${options?.later ?? 0}`;
+      }
+      if (options?.today !== undefined || options?.allTime !== undefined) {
+        return `${key}:${options?.today ?? 0}/${options?.allTime ?? 0}`;
+      }
+      return key;
+    },
+    i18n: { language: "en" },
+  }),
+}));
+
+jest.mock("@/hooks/useTypedTranslation", () => ({
+  useFormsTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock("@/hooks/useThrottledRefetchOnFocus", () => ({
+  useThrottledRefetchOnFocus: jest.fn(),
+}));
+
+jest.mock("react-router-dom", () => {
+  const actual = jest.requireActual("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useParams: () => ({}),
+    useSearchParams: () => [new URLSearchParams(), jest.fn()],
+  };
+});
+
+jest.mock("@/hooks/use-toast", () => ({
+  toast: jest.fn(),
+}));
+
+const sanitizeTestId = (value: string) => value.replace(/[^a-z0-9]+/gi, "-").toLowerCase();
+
+jest.mock("@/components/ui/kpi-card", () => ({
+  KpiCard: ({ title, value, info }: any) => (
+    <div data-testid={`kpi-${sanitizeTestId(String(title))}`}>
+      <span data-testid={`kpi-${sanitizeTestId(String(title))}-value`}>{value}</span>
+      {info?.content ? <span>{info.content}</span> : null}
+    </div>
+  ),
+}));
+
+jest.mock("@/components/ui/kpi-presets", () => ({
+  getKpiIconPreset: () => ({}),
+}));
+
+jest.mock("@/components/ui/button", () => ({
+  Button: ({ children, onClick, ...rest }: any) => (
+    <button type="button" onClick={onClick} {...rest}>
+      {children}
+    </button>
+  ),
+}));
+
+jest.mock("@/components/ui/switch", () => ({
+  Switch: ({ checked, onCheckedChange }: any) => (
+    <button
+      type="button"
+      aria-pressed={checked}
+      onClick={() => onCheckedChange(!checked)}
+    >
+      {checked ? "on" : "off"}
+    </button>
+  ),
+}));
+
+jest.mock("@/components/ui/badge", () => ({
+  Badge: ({ children, ...rest }: any) => (
+    <span {...rest}>{children}</span>
+  ),
+}));
+
+jest.mock("@/components/ui/page-header", () => ({
+  PageHeader: ({ title, subtitle, children }: any) => (
+    <div>
+      <h1>{title}</h1>
+      <p>{subtitle}</p>
+      {children}
+    </div>
+  ),
+  PageHeaderSearch: ({ children }: any) => <div>{children}</div>,
+}));
+
+jest.mock("@/components/GlobalSearch", () => () => <div data-testid="global-search" />);
+
+jest.mock("@/components/FilterBar", () => ({
+  FilterBar: ({ quickFilters = [], onQuickFilterChange = () => {}, showCompleted, onShowCompletedChange = () => {}, hideOverdue, onHideOverdueChange = () => {} }: any) => (
+    <div data-testid="filter-bar">
+      {quickFilters.map((filter: any) => (
+        <button
+          key={filter.key}
+          type="button"
+          onClick={() => onQuickFilterChange(filter.key)}
+        >
+          {filter.label}:{filter.count}
+        </button>
+      ))}
+      <button type="button" onClick={() => onShowCompletedChange(!showCompleted)}>
+        toggle-completed
+      </button>
+      <button type="button" onClick={() => onHideOverdueChange(!hideOverdue)}>
+        toggle-overdue
+      </button>
+    </div>
+  ),
+}));
+
+jest.mock("@/components/ui/loading-presets", () => ({
+  ListLoadingSkeleton: () => <div data-testid="loading-skeleton" />,
+}));
+
+jest.mock("@/components/ViewProjectDialog", () => ({
+  ViewProjectDialog: ({ open, project, leadName }: any) =>
+    open ? (
+      <div data-testid="view-project-dialog">
+        {project?.name} - {leadName}
+      </div>
+    ) : null,
+}));
+
+jest.mock("@/components/ui/accordion", () => ({
+  Accordion: ({ children }: any) => <div>{children}</div>,
+  AccordionItem: ({ children }: any) => <div>{children}</div>,
+  AccordionTrigger: ({ children, onClick }: any) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+  AccordionContent: ({ children }: any) => <div>{children}</div>,
+}));
+
+const mockToast = toast as jest.Mock;
+const mockSupabaseFrom = supabase.from as jest.Mock;
+
+interface Activity {
+  id: string;
+  content: string;
+  reminder_date: string;
+  reminder_time: string | null;
+  type: string;
+  lead_id: string;
+  project_id?: string | null;
+  created_at: string;
+  updated_at: string;
+  completed?: boolean;
+}
+
+interface Lead {
+  id: string;
+  name: string;
+  status: string;
+}
+
+const createActivitiesQuery = (activities: Activity[], error?: Error) => {
+  const query: any = {};
+  let orderCalls = 0;
+  query.select = jest.fn(() => query);
+  query.not = jest.fn(() => query);
+  query.order = jest.fn(() => {
+    orderCalls += 1;
+    if (orderCalls >= 2) {
+      if (error) {
+        return Promise.resolve({ data: null, error });
+      }
+      return Promise.resolve({ data: activities, error: null });
+    }
+    return query;
+  });
+  return query;
+};
+
+const createLeadsQuery = (leads: Lead[], error?: Error) => {
+  const query: any = {};
+  query.select = jest.fn(() => query);
+  query.in = jest.fn(() => Promise.resolve({ data: error ? null : leads, error: error ?? null }));
+  query.eq = jest.fn(() => query);
+  query.single = jest.fn(() => Promise.resolve({ data: error ? null : leads[0], error: error ?? null }));
+  return query;
+};
+
+const createUpdateActivityQuery = (error?: Error) => {
+  const query: any = {};
+  query.update = jest.fn(() => query);
+  query.eq = jest.fn(() => Promise.resolve({ error: error ?? null }));
+  return query;
+};
+
+const createProjectQuery = (project: any, error?: Error) => {
+  const query: any = {};
+  query.select = jest.fn(() => query);
+  query.eq = jest.fn(() => query);
+  query.single = jest.fn(() => Promise.resolve({ data: error ? null : project, error: error ?? null }));
+  return query;
+};
+
+const createLeadSingleQuery = (lead: Lead, error?: Error) => {
+  const query: any = {};
+  query.select = jest.fn(() => query);
+  query.eq = jest.fn(() => query);
+  query.single = jest.fn(() => Promise.resolve({ data: error ? null : lead, error: error ?? null }));
+  return query;
+};
+
+const iso = (value: string) => new Date(value).toISOString();
+
+describe("ReminderDetails page", () => {
+  const RealDate = Date;
+  const fixedDate = new RealDate("2024-05-20T12:00:00.000Z");
+
+  beforeAll(() => {
+    class FixedDate extends RealDate {
+      constructor(...args: any[]) {
+        if (args.length === 0) {
+          super(fixedDate.toISOString());
+        } else {
+          super(...args);
+        }
+      }
+
+      static now() {
+        return fixedDate.getTime();
+      }
+    }
+
+    global.Date = FixedDate as unknown as DateConstructor;
+  });
+
+  afterAll(() => {
+    global.Date = RealDate;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSupabaseFrom.mockReset();
+    mockToast.mockReset();
+    mockNavigate.mockReset();
+  });
+
+  it("renders reminder metrics and timeline from fetched data", async () => {
+    const activities: Activity[] = [
+      {
+        id: "activity-overdue",
+        content: "Follow up overdue",
+        reminder_date: iso("2024-05-18T00:00:00.000Z"),
+        reminder_time: null,
+        type: "call",
+        lead_id: "lead-1",
+        created_at: iso("2024-05-01T00:00:00.000Z"),
+        updated_at: iso("2024-05-01T00:00:00.000Z"),
+      },
+      {
+        id: "activity-today",
+        content: "Call prospect",
+        reminder_date: iso("2024-05-20T00:00:00.000Z"),
+        reminder_time: "09:30",
+        type: "call",
+        lead_id: "lead-2",
+        created_at: iso("2024-05-02T00:00:00.000Z"),
+        updated_at: iso("2024-05-02T00:00:00.000Z"),
+      },
+      {
+        id: "activity-upcoming",
+        content: "Prep materials",
+        reminder_date: iso("2024-05-21T00:00:00.000Z"),
+        reminder_time: "13:00",
+        type: "task",
+        lead_id: "lead-1",
+        project_id: "project-7",
+        created_at: iso("2024-05-03T00:00:00.000Z"),
+        updated_at: iso("2024-05-03T00:00:00.000Z"),
+      },
+      {
+        id: "activity-completed",
+        content: "Send recap",
+        reminder_date: iso("2024-05-20T00:00:00.000Z"),
+        reminder_time: null,
+        type: "email",
+        lead_id: "lead-2",
+        created_at: iso("2024-05-04T00:00:00.000Z"),
+        updated_at: iso("2024-05-04T00:00:00.000Z"),
+        completed: true,
+      },
+    ];
+
+    const leads: Lead[] = [
+      { id: "lead-1", name: "Alice Johnson", status: "active" },
+      { id: "lead-2", name: "Bob Smith", status: "active" },
+    ];
+
+    mockSupabaseFrom
+      .mockImplementationOnce(() => createActivitiesQuery(activities))
+      .mockImplementationOnce(() => createLeadsQuery(leads));
+
+    render(<ReminderDetails />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("loading-skeleton")).not.toBeInTheDocument();
+    });
+
+    expect(await screen.findByTestId("kpi-reminders-stats-overdue-value")).toHaveTextContent("1");
+    expect(screen.getByTestId("kpi-reminders-stats-today-value")).toHaveTextContent("1");
+    expect(screen.getByTestId("kpi-reminders-stats-upcoming-value")).toHaveTextContent("1");
+    expect(screen.getByTestId("kpi-reminders-stats-completed-value")).toHaveTextContent("1");
+
+    expect(await screen.findByText("Call prospect")).toBeInTheDocument();
+    expect(screen.getByText("Follow up overdue")).toBeInTheDocument();
+
+    const allFilterButtons = screen.getAllByRole("button", { name: /reminders\.filters\.all/ });
+    fireEvent.click(allFilterButtons[0]);
+
+    expect(await screen.findByText("Prep materials")).toBeInTheDocument();
+
+    const aliceNames = screen.getAllByText("Alice Johnson");
+    const bobNames = screen.getAllByText("Bob Smith");
+    expect(aliceNames.length).toBeGreaterThan(0);
+    expect(bobNames.length).toBeGreaterThan(0);
+
+    const openLeadButtons = screen.getAllByRole("button", { name: "reminders.timeline.openLead" });
+    fireEvent.click(openLeadButtons[0]);
+
+    expect(mockNavigate).toHaveBeenCalledWith("/leads/lead-1");
+    expect(mockSupabaseFrom).toHaveBeenNthCalledWith(1, "activities");
+    expect(mockSupabaseFrom).toHaveBeenNthCalledWith(2, "leads");
+  });
+
+  it("surfaces a destructive toast when reminder fetching fails", async () => {
+    const error = new Error("network down");
+    mockSupabaseFrom.mockImplementationOnce(() => createActivitiesQuery([], error));
+
+    render(<ReminderDetails />);
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Error fetching reminders",
+          description: "network down",
+          variant: "destructive",
+        })
+      );
+    });
+  });
+
+  it("toggles reminder completion state and shows success feedback", async () => {
+    const activity: Activity = {
+      id: "activity-1",
+      content: "Confirm booking",
+      reminder_date: iso("2024-05-20T00:00:00.000Z"),
+      reminder_time: "11:00",
+      type: "call",
+      lead_id: "lead-1",
+      created_at: iso("2024-05-01T00:00:00.000Z"),
+      updated_at: iso("2024-05-01T00:00:00.000Z"),
+    };
+
+    const leads: Lead[] = [{ id: "lead-1", name: "Jordan Ray", status: "active" }];
+
+    const updateQuery = createUpdateActivityQuery();
+
+    mockSupabaseFrom
+      .mockImplementationOnce(() => createActivitiesQuery([activity]))
+      .mockImplementationOnce(() => createLeadsQuery(leads))
+      .mockImplementationOnce(() => updateQuery);
+
+    render(<ReminderDetails />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("loading-skeleton")).not.toBeInTheDocument();
+    });
+
+    const completeButton = await screen.findByRole("button", { name: "reminders.markComplete" });
+    fireEvent.click(completeButton);
+
+    await waitFor(() => {
+      expect(updateQuery.update).toHaveBeenCalledWith({ completed: true });
+      expect(updateQuery.eq).toHaveBeenCalledWith("id", "activity-1");
+    });
+
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Reminder marked as completed",
+        description: "Reminder status updated successfully.",
+      })
+    );
+
+    fireEvent.click(screen.getByText("toggle-completed"));
+
+    expect(await screen.findByRole("button", { name: "reminders.markIncomplete" })).toBeInTheDocument();
+  });
+
+  it("loads project details when project navigation is requested", async () => {
+    const activity: Activity = {
+      id: "activity-with-project",
+      content: "Review proposal",
+      reminder_date: iso("2024-05-21T00:00:00.000Z"),
+      reminder_time: null,
+      type: "task",
+      lead_id: "lead-1",
+      project_id: "project-42",
+      created_at: iso("2024-05-01T00:00:00.000Z"),
+      updated_at: iso("2024-05-01T00:00:00.000Z"),
+    };
+
+    const initialLeads: Lead[] = [{ id: "lead-1", name: "Devon Lane", status: "active" }];
+
+    const project = {
+      id: "project-42",
+      name: "Project Phoenix",
+      description: "High priority",
+      lead_id: "lead-2",
+      user_id: "user-1",
+      created_at: iso("2024-05-01T00:00:00.000Z"),
+      updated_at: iso("2024-05-01T00:00:00.000Z"),
+      status_id: "status-1",
+      previous_status_id: null,
+      project_type_id: "type-1",
+    };
+
+    const projectLead: Lead = { id: "lead-2", name: "Taylor Bright", status: "active" };
+
+    mockSupabaseFrom
+      .mockImplementationOnce(() => createActivitiesQuery([activity]))
+      .mockImplementationOnce(() => createLeadsQuery(initialLeads))
+      .mockImplementationOnce(() => createProjectQuery(project))
+      .mockImplementationOnce(() => createLeadSingleQuery(projectLead));
+
+    render(<ReminderDetails />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("loading-skeleton")).not.toBeInTheDocument();
+    });
+
+    const allFilterButtons = await screen.findAllByRole("button", { name: /reminders\.filters\.all/ });
+    fireEvent.click(allFilterButtons[0]);
+
+    const openProjectButton = await screen.findByRole("button", { name: "reminders.timeline.openProject" });
+    fireEvent.click(openProjectButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("view-project-dialog")).toHaveTextContent("Project Phoenix - Taylor Bright");
+    });
+
+    expect(mockSupabaseFrom).toHaveBeenNthCalledWith(3, "projects");
+    expect(mockSupabaseFrom).toHaveBeenNthCalledWith(4, "leads");
+  });
+});


### PR DESCRIPTION
## Summary
- add a ReminderDetails page test suite that covers successful fetches, filter interactions, error toasts, completion toggles, and project dialog loading
- update the unit testing tracker snapshot, inventory entry, and iteration log to reflect the new coverage

## Testing
- npm test -- --runTestsByPath src/pages/__tests__/ReminderDetails.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68fd17c0b0fc8321860ed66dfe385d58