### PR TITLE
Add legacy payment and lead dialog tests

### DIFF
--- a/docs/unit-testing-plan.md
+++ b/docs/unit-testing-plan.md
@@ -39,10 +39,10 @@
 | Core Libraries & Helpers | 13 | 13 | 100% |
 | Services & Data Access | 5 | 5 | 100% |
 | Contexts & Hooks | 27 | 27 | 100% |
-| UI Components & Pages | 71 | 73 | 97% |
+| UI Components & Pages | 75 | 77 | 97% |
 | UI Primitives & Shared Components | 18 | 18 | 100% |
 | Supabase Edge Functions & Automation | 9 | 9 | 100% |
-| **Overall** | **143** | **145** | **99%** |
+| **Overall** | **147** | **149** | **99%** |
 
 ### Core Libraries & Helpers
 | Area | File(s) | What to Cover | Priority | Status | Notes |
@@ -102,6 +102,8 @@
 ### UI Components & Pages
 | Area | File(s) | What to Cover | Priority | Status | Notes |
 | --- | --- | --- | --- | --- | --- |
+| Add lead dialog | `src/components/AddLeadDialog.tsx` | Required fields guard, sanitized payload, status filtering, navigation guard | High | Done | Covered by `src/components/__tests__/AddLeadDialog.test.tsx` validating disabled submit, trimmed payload insert, filtered statuses, and dirty-close handling. |
+| Edit lead dialog | `src/components/EditLeadDialog.tsx` | Prefill defaults, status lookup, validation disabling, guard reset | High | Done | Covered by `src/components/__tests__/EditLeadDialog.test.tsx` ensuring prefill, blank-name disablement, Supabase update payload, and guard callbacks. |
 | Enhanced lead creation | `src/components/EnhancedAddLeadDialog.tsx` | Dynamic schema init, default status lookup, save pipeline | High | Done | Covered by `src/components/__tests__/EnhancedAddLeadDialog.test.tsx` verifying default status creation, value persistence, and navigation guard. |
 | Enhanced lead edit | `src/components/EnhancedEditLeadDialog.tsx` | Prefill logic, change detection, update mutation flow | High | Done | Covered by `src/components/__tests__/EnhancedEditLeadDialog.test.tsx` for prefill, validation, and Supabase updates. |
 | Enhanced project dialog | `src/components/EnhancedProjectDialog.tsx` | Cross-entity linking, lead selection, Supabase upserts | High | Done | Covered by `src/components/__tests__/EnhancedProjectDialog.test.tsx` ensuring data fetch, custom setup, and close/reopen resets. |
@@ -109,6 +111,8 @@
 | Session scheduling sheet | `src/components/SessionSchedulingSheet.tsx` | Mobile sheet state, timezone-aware slots, submission flow | Medium | Done | Covered by `src/components/__tests__/SessionSchedulingSheet.test.tsx` validating slot selection, summary updates, and guarded closing. |
 | Project Kanban board | `src/components/ProjectKanbanBoard.tsx` | Drag/drop ordering, status filtering, performance memoization | Medium | Done | Covered by `src/components/__tests__/ProjectKanbanBoard.test.tsx` for multi-status rendering, no-status fallback, quick view wiring, and pagination actions. |
 | Workflow health dashboard | `src/components/WorkflowHealthDashboard.tsx` | Status aggregations, error states, filter interactions | Medium | Done | Covered by `src/components/__tests__/WorkflowHealthDashboard.test.tsx` for loading skeleton, empty state, critical metrics, and action buttons. |
+| Add payment dialog | `src/components/AddPaymentDialog.tsx` | Required field gating, insert payload shaping, due status propagation | High | Done | Covered by `src/components/__tests__/AddPaymentDialog.test.tsx` asserting disabled submit, insert/reset flow, due status toggles, and guard reset callbacks. |
+| Edit payment dialog | `src/components/EditPaymentDialog.tsx` | Prefill hydration, manual/base payment branching, status guardrails | High | Done | Covered by `src/components/__tests__/EditPaymentDialog.test.tsx` verifying prefills, manual/base mutation payloads, due status handling, and dirty-close guard. |
 | Global search | `src/components/GlobalSearch.tsx` | Debounced queries, status preload, keyboard navigation | High | Done | Covered by `src/components/__tests__/GlobalSearch.test.tsx` (debounce guard, preloaded statuses, keyboard selection). |
 | Protected route guard | `src/components/ProtectedRoute.tsx` | Auth gating, redirect logic, loading fallback | Medium | Done | Covered by `src/components/__tests__/ProtectedRoute.test.tsx` (loading/redirect + onboarding guard). |
 | Route prefetcher | `src/components/RoutePrefetcher.tsx` | Prefetch orchestration, duplicate avoidance | Medium | Done | Covered by `src/components/__tests__/RoutePrefetcher.test.tsx` (cache guard + Supabase prefetch). |
@@ -299,6 +303,7 @@ _Statuses_: `Not started`, `In progress`, `Blocked`, `Ready for review`, `Done`.
 | 2025-11-12 | Codex | Added Payments workspace page + component coverage | Added `src/pages/__tests__/Payments.test.tsx` alongside component specs for date controls, trend chart, metrics summary, and table section to verify filter resets, export flows, formatter output, and chart/empty states | Next: extend coverage to ReminderDetails page and remaining settings screens |
 | 2025-11-13 | Codex | Added calendar component coverage | Added `src/components/calendar/__tests__/CalendarDay.test.tsx`, `CalendarDayView.test.tsx`, `CalendarMonthView.test.tsx`, `CalendarWeek.test.tsx`, `CalendarSkeleton.test.tsx`, and `CalendarErrorBoundary.test.tsx` to cover mobile/day/month/week interactions, skeleton scaffolds, and error recovery flows | Next: Explore coverage for calendar virtualization performance metrics and touch gesture edge cases |
 | 2025-11-14 | Codex | Added reminder details page coverage | Added `src/pages/__tests__/ReminderDetails.test.tsx` to validate reminder stats, fetch error toasts, completion toggles, navigation, and project dialog fetches | Keep an eye on future reminder reschedule flows or provider refactors |
+| 2025-11-15 | Codex | Added legacy payment & lead dialog coverage | Added `src/components/__tests__/AddPaymentDialog.test.tsx`, `EditPaymentDialog.test.tsx`, `AddLeadDialog.test.tsx`, and `EditLeadDialog.test.tsx`; refreshed progress snapshot totals | Monitor dialog flows if currency/localization options expand or navigation guard messaging changes |
 
 ## Maintenance Rules of Thumb
 - Treat this file like the single source of truth for unit testing status—update it in the same PR as any test additions or strategy changes.

--- a/src/components/__tests__/AddLeadDialog.test.tsx
+++ b/src/components/__tests__/AddLeadDialog.test.tsx
@@ -1,0 +1,359 @@
+import type { ComponentProps } from "react";
+import { fireEvent, render, screen, waitFor } from "@/utils/testUtils";
+import AddLeadDialog from "../AddLeadDialog";
+import { mockSupabaseClient } from "@/utils/testUtils";
+import { useI18nToast } from "@/lib/toastHelpers";
+import { getUserOrganizationId } from "@/lib/organizationUtils";
+import { useOrganizationQuickSettings } from "@/hooks/useOrganizationQuickSettings";
+import { useModalNavigation } from "@/hooks/useModalNavigation";
+import { useProfile } from "@/contexts/ProfileContext";
+import { leadSchema, sanitizeHtml, sanitizeInput } from "@/lib/validation";
+import { ZodError } from "zod";
+
+jest.mock("@/integrations/supabase/client", () => ({
+  supabase: mockSupabaseClient,
+}));
+
+jest.mock("@/lib/toastHelpers", () => ({
+  useI18nToast: jest.fn(),
+}));
+
+jest.mock("@/lib/organizationUtils", () => ({
+  getUserOrganizationId: jest.fn(),
+}));
+
+jest.mock("@/hooks/useOrganizationQuickSettings", () => ({
+  useOrganizationQuickSettings: jest.fn(() => ({ settings: { show_quick_status_buttons: true } })),
+}));
+
+jest.mock("@/contexts/ProfileContext", () => ({
+  useProfile: jest.fn(() => ({ profile: { id: "profile-1" } })),
+}));
+
+jest.mock("@/hooks/useModalNavigation", () => ({
+  useModalNavigation: jest.fn(),
+}));
+
+jest.mock("@/components/ui/app-sheet-modal", () => ({
+  AppSheetModal: ({
+    title,
+    dirty,
+    children,
+    footerActions = [],
+    onDirtyClose,
+  }: any) => (
+    <div data-testid="app-sheet-modal" data-title={title} data-dirty={dirty ? "dirty" : "clean"}>
+      {children}
+      {footerActions.map((action: any, index: number) => (
+        <button
+          key={index}
+          data-testid={`footer-action-${index}`}
+          disabled={action.disabled}
+          onClick={action.onClick}
+        >
+          {action.label}
+        </button>
+      ))}
+      <button type="button" data-testid="dirty-close" onClick={() => onDirtyClose?.()}>
+        close-modal
+      </button>
+    </div>
+  ),
+}));
+
+jest.mock("@/components/ui/select", () => ({
+  Select: ({ value, onValueChange, children }: any) => (
+    <select data-testid="status-select" value={value} onChange={(event) => onValueChange(event.target.value)}>
+      {children}
+    </select>
+  ),
+  SelectTrigger: () => null,
+  SelectValue: () => null,
+  SelectContent: ({ children }: any) => <>{children}</>,
+  SelectItem: ({ value, children }: any) => (
+    <option value={value}>{typeof children === "string" ? children : value}</option>
+  ),
+}));
+
+jest.mock("../settings/NavigationGuardDialog", () => ({
+  NavigationGuardDialog: ({ open, message, onDiscard, onStay, onSaveAndExit }: any) =>
+    open ? (
+      <div data-testid="navigation-guard">
+        <p>{message}</p>
+        <button onClick={onStay}>stay</button>
+        {onSaveAndExit && <button onClick={onSaveAndExit}>save-exit</button>}
+        <button onClick={onDiscard}>discard</button>
+      </div>
+    ) : null,
+}));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, string>) =>
+      options?.name ? `${key}:${options.name}` : key,
+  }),
+}));
+
+jest.mock("@/lib/validation", () => {
+  const actual = jest.requireActual("@/lib/validation");
+  return {
+    ...actual,
+    leadSchema: { parseAsync: jest.fn() },
+    sanitizeInput: jest.fn((value: string) => value.trim()),
+    sanitizeHtml: jest.fn(async (value: string) => value),
+  };
+});
+
+const toastMock = {
+  success: jest.fn(),
+  error: jest.fn(),
+};
+
+const mockHandleModalClose = jest.fn();
+const mockHandleDiscard = jest.fn();
+const mockHandleStay = jest.fn();
+const mockHandleSaveAndExit = jest.fn();
+
+const mockUseModalNavigation = useModalNavigation as jest.Mock;
+const mockUseI18nToast = useI18nToast as jest.Mock;
+const mockGetUserOrganizationId = getUserOrganizationId as jest.Mock;
+const mockUseOrganizationQuickSettings = useOrganizationQuickSettings as jest.Mock;
+const mockUseProfile = useProfile as jest.Mock;
+
+const mockLeadSchemaParseAsync = (leadSchema as unknown as { parseAsync: jest.Mock }).parseAsync;
+const mockSanitizeInput = sanitizeInput as jest.Mock;
+const mockSanitizeHtml = sanitizeHtml as jest.Mock;
+
+const createStatusFetch = (statuses: any[]) => {
+  const order = jest.fn().mockResolvedValue({ data: statuses, error: null });
+  const select = jest.fn().mockReturnValue({ order });
+  return { select, order };
+};
+
+const createDefaultFromResponse = () => ({
+  select: jest.fn().mockReturnThis(),
+  insert: jest.fn().mockReturnThis(),
+  update: jest.fn().mockReturnThis(),
+  delete: jest.fn().mockReturnThis(),
+  eq: jest.fn().mockReturnThis(),
+  in: jest.fn().mockReturnThis(),
+  order: jest.fn().mockReturnThis(),
+  limit: jest.fn().mockReturnThis(),
+  single: jest.fn(),
+});
+
+const originalFromImplementation = (mockSupabaseClient.from.getMockImplementation() || ((table: string) => createDefaultFromResponse())) as (
+  table: string
+) => any;
+
+describe("AddLeadDialog", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    if (originalFromImplementation) {
+      mockSupabaseClient.from.mockImplementation(originalFromImplementation);
+    }
+    mockSupabaseClient.from.mockClear();
+    mockSupabaseClient.auth.getUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
+    mockUseI18nToast.mockReturnValue(toastMock);
+    mockGetUserOrganizationId.mockResolvedValue("org-1");
+    mockUseOrganizationQuickSettings.mockReturnValue({ settings: { show_quick_status_buttons: true } });
+    mockUseProfile.mockReturnValue({ profile: { id: "profile-1" } });
+
+    mockHandleModalClose.mockReturnValue(true);
+    mockHandleDiscard.mockImplementation(() => {});
+    mockHandleStay.mockImplementation(() => {});
+    mockHandleSaveAndExit.mockImplementation(async () => {});
+
+    mockUseModalNavigation.mockImplementation(() => ({
+      showGuard: false,
+      message: "guard",
+      handleModalClose: mockHandleModalClose,
+      handleDiscardChanges: mockHandleDiscard,
+      handleStayOnModal: mockHandleStay,
+      handleSaveAndExit: mockHandleSaveAndExit,
+    }));
+
+    mockLeadSchemaParseAsync.mockResolvedValue(true);
+    mockSanitizeInput.mockImplementation((value: string) => value.trim());
+    mockSanitizeHtml.mockImplementation(async (value: string) => value);
+  });
+
+  afterEach(() => {
+    if (originalFromImplementation) {
+      mockSupabaseClient.from.mockImplementation(originalFromImplementation);
+    }
+  });
+
+  const renderDialog = (props: Partial<ComponentProps<typeof AddLeadDialog>> = {}) => {
+    const defaultProps = {
+      onLeadAdded: jest.fn(),
+      open: true,
+      onOpenChange: jest.fn(),
+    } satisfies ComponentProps<typeof AddLeadDialog>;
+
+    return render(<AddLeadDialog {...defaultProps} {...props} />);
+  };
+
+  it("disables submission while the name field is empty", async () => {
+    const statuses = [
+      { id: "status-1", name: "New", color: "#ff0", is_system_final: false },
+    ];
+
+    const { select } = createStatusFetch(statuses);
+
+    mockSupabaseClient.from.mockImplementation((table: string) => {
+      if (table === "lead_statuses") {
+        return { select } as any;
+      }
+      if (table === "leads") {
+        return { insert: jest.fn() } as any;
+      }
+      return originalFromImplementation ? originalFromImplementation(table) : ({} as any);
+    });
+
+    renderDialog();
+
+    await waitFor(() => {
+      expect(select).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("status-select")).toHaveValue("New");
+    });
+
+    expect(screen.getByTestId("footer-action-1")).toBeDisabled();
+    expect(toastMock.error).not.toHaveBeenCalled();
+  });
+
+  it("creates a lead with sanitized payload and resets the form", async () => {
+    const insertMock = jest.fn().mockResolvedValue({ error: null });
+
+    mockSanitizeHtml.mockResolvedValue("sanitized notes");
+
+    const statuses = [
+      { id: "status-1", name: "New", color: "#ff0", is_system_final: false },
+    ];
+
+    const { select } = createStatusFetch(statuses);
+
+    mockSupabaseClient.from.mockImplementation((table: string) => {
+      if (table === "lead_statuses") {
+        return { select } as any;
+      }
+      if (table === "leads") {
+        return {
+          insert: insertMock,
+        } as any;
+      }
+      return {} as any;
+    });
+
+    const onLeadAdded = jest.fn();
+    const onOpenChange = jest.fn();
+
+    renderDialog({ onLeadAdded, onOpenChange });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("status-select")).toHaveValue("New");
+    });
+
+    fireEvent.change(screen.getByLabelText(/forms:labels.name/i), { target: { value: "  Taylor  " } });
+    fireEvent.change(screen.getByLabelText(/forms:labels.email/i), { target: { value: "user@example.com" } });
+    fireEvent.change(screen.getByLabelText(/forms:labels.notes/i), { target: { value: "Needs info" } });
+
+    expect(screen.getByTestId("footer-action-1")).not.toBeDisabled();
+
+    fireEvent.click(screen.getByTestId("footer-action-1"));
+
+    await waitFor(() => {
+      expect(mockLeadSchemaParseAsync).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(insertMock).toHaveBeenCalled();
+    });
+
+    expect(insertMock).toHaveBeenCalledWith([
+      expect.objectContaining({
+        user_id: "user-1",
+        organization_id: "org-1",
+        name: "Taylor",
+        email: "user@example.com",
+        notes: "sanitized notes",
+        status: "New",
+      }),
+    ]);
+
+    expect(toastMock.success).toHaveBeenCalledWith("forms:messages.leadAddedDesc:  Taylor  ");
+    expect(onLeadAdded).toHaveBeenCalled();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+
+    await waitFor(() => {
+      expect((screen.getByLabelText(/forms:labels.name/i) as HTMLInputElement).value).toBe("");
+      expect((screen.getByLabelText(/forms:labels.email/i) as HTMLInputElement).value).toBe("");
+      expect((screen.getByLabelText(/forms:labels.notes/i) as HTMLTextAreaElement).value).toBe("");
+    });
+  });
+
+  it("filters final statuses when quick status buttons are disabled", async () => {
+    const statuses = [
+      { id: "status-1", name: "New", color: "#ff0", is_system_final: false },
+      { id: "status-2", name: "Won", color: "#0f0", is_system_final: true },
+    ];
+
+    const { select } = createStatusFetch(statuses);
+
+    mockUseOrganizationQuickSettings.mockReturnValue({ settings: { show_quick_status_buttons: false } });
+
+    mockSupabaseClient.from.mockImplementation((table: string) => {
+      if (table === "lead_statuses") {
+        return { select } as any;
+      }
+      return { insert: jest.fn() } as any;
+    });
+
+    renderDialog();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("status-select")).toHaveValue("New");
+    });
+
+    const options = screen.getAllByRole("option").map((option) => option.textContent);
+    expect(options).toEqual(["New"]);
+  });
+
+  it("invokes navigation guard handlers when the dialog has unsaved changes", async () => {
+    const statuses = [
+      { id: "status-1", name: "New", color: "#ff0", is_system_final: false },
+    ];
+
+    const { select } = createStatusFetch(statuses);
+
+    mockSupabaseClient.from.mockImplementation((table: string) => {
+      if (table === "lead_statuses") {
+        return { select } as any;
+      }
+      return { insert: jest.fn() } as any;
+    });
+
+    renderDialog();
+
+    await waitFor(() => {
+      expect(select).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("status-select")).toHaveValue("New");
+    });
+
+    fireEvent.change(screen.getByLabelText(/forms:labels.name/i), { target: { value: "Alex" } });
+
+    fireEvent.click(screen.getByTestId("dirty-close"));
+
+    expect(mockHandleModalClose).toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect((screen.getByLabelText(/forms:labels.name/i) as HTMLInputElement).value).toBe("");
+    });
+  });
+});

--- a/src/components/__tests__/AddPaymentDialog.test.tsx
+++ b/src/components/__tests__/AddPaymentDialog.test.tsx
@@ -1,0 +1,257 @@
+import { fireEvent, render, screen, waitFor } from "@/utils/testUtils";
+import { AddPaymentDialog } from "../AddPaymentDialog";
+import { mockSupabaseClient } from "@/utils/testUtils";
+import { useI18nToast } from "@/lib/toastHelpers";
+import { getUserOrganizationId } from "@/lib/organizationUtils";
+import { useFormsTranslation } from "@/hooks/useTypedTranslation";
+import { useModalNavigation } from "@/hooks/useModalNavigation";
+
+jest.mock("@/integrations/supabase/client", () => ({
+  supabase: mockSupabaseClient,
+}));
+
+jest.mock("@/lib/toastHelpers", () => ({
+  useI18nToast: jest.fn(),
+}));
+
+jest.mock("@/hooks/useTypedTranslation", () => ({
+  useFormsTranslation: jest.fn(),
+}));
+
+jest.mock("@/lib/organizationUtils", () => ({
+  getUserOrganizationId: jest.fn(),
+}));
+
+jest.mock("@/hooks/useModalNavigation", () => ({
+  useModalNavigation: jest.fn(),
+}));
+
+jest.mock("@/components/ui/app-sheet-modal", () => ({
+  AppSheetModal: ({
+    title,
+    dirty,
+    children,
+    footerActions = [],
+    onDirtyClose,
+  }: any) => (
+    <div data-testid="app-sheet-modal" data-title={title} data-dirty={dirty ? "dirty" : "clean"}>
+      {children}
+      {footerActions.map((action: any, index: number) => (
+        <button
+          key={index}
+          data-testid={`footer-action-${index}`}
+          disabled={action.disabled}
+          onClick={action.onClick}
+        >
+          {action.label}
+        </button>
+      ))}
+      <button type="button" data-testid="dirty-close" onClick={() => onDirtyClose?.()}>
+        close-modal
+      </button>
+    </div>
+  ),
+}));
+
+jest.mock("@/components/ui/select", () => ({
+  Select: ({ value, onValueChange, children }: any) => (
+    <select data-testid="status-select" value={value} onChange={(event) => onValueChange(event.target.value)}>
+      {children}
+    </select>
+  ),
+  SelectTrigger: () => null,
+  SelectValue: () => null,
+  SelectContent: ({ children }: any) => <>{children}</>,
+  SelectItem: ({ value, children }: any) => (
+    <option value={value}>{typeof children === "string" ? children : value}</option>
+  ),
+}));
+
+jest.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: any) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: any) => <div>{children}</div>,
+  PopoverContent: ({ children }: any) => <div>{children}</div>,
+}));
+
+jest.mock("../settings/NavigationGuardDialog", () => ({
+  NavigationGuardDialog: ({ open, message, onDiscard, onStay }: any) =>
+    open ? (
+      <div data-testid="navigation-guard">
+        <p>{message}</p>
+        <button onClick={onStay}>stay</button>
+        <button onClick={onDiscard}>discard</button>
+      </div>
+    ) : null,
+}));
+
+jest.mock("react-calendar", () => ({
+  __esModule: true,
+  default: ({ onChange }: { onChange: (value: Date) => void }) => (
+    <button data-testid="calendar-trigger" onClick={() => onChange(new Date("2024-01-02T00:00:00Z"))}>
+      pick-date
+    </button>
+  ),
+}));
+
+jest.mock("@/lib/utils", () => ({
+  ...jest.requireActual("@/lib/utils"),
+  getUserLocale: jest.fn(() => "en-US"),
+  getDateFnsLocale: jest.fn(() => undefined),
+  cn: (...classes: string[]) => classes.filter(Boolean).join(" "),
+}));
+
+jest.mock("react-calendar/dist/Calendar.css", () => ({}), { virtual: true });
+jest.mock("@/components/react-calendar.css", () => ({}), { virtual: true });
+
+const toastMock = {
+  success: jest.fn(),
+  error: jest.fn(),
+};
+
+const mockHandleModalClose = jest.fn();
+const mockHandleDiscard = jest.fn();
+const mockHandleStay = jest.fn();
+const mockHandleSaveAndExit = jest.fn();
+
+const mockUseModalNavigation = useModalNavigation as jest.Mock;
+const mockUseI18nToast = useI18nToast as jest.Mock;
+const mockUseFormsTranslation = useFormsTranslation as jest.Mock;
+const mockGetUserOrganizationId = getUserOrganizationId as jest.Mock;
+
+const createDefaultFromResponse = () => ({
+  select: jest.fn().mockReturnThis(),
+  insert: jest.fn().mockReturnThis(),
+  update: jest.fn().mockReturnThis(),
+  delete: jest.fn().mockReturnThis(),
+  eq: jest.fn().mockReturnThis(),
+  in: jest.fn().mockReturnThis(),
+  order: jest.fn().mockReturnThis(),
+  limit: jest.fn().mockReturnThis(),
+  single: jest.fn(),
+});
+
+const originalFromImplementation = (mockSupabaseClient.from.getMockImplementation() || ((table: string) => createDefaultFromResponse())) as (
+  table: string
+) => any;
+
+describe("AddPaymentDialog", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSupabaseClient.from.mockImplementation(originalFromImplementation);
+    mockSupabaseClient.from.mockClear();
+    mockSupabaseClient.auth.getUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
+    mockUseI18nToast.mockReturnValue(toastMock);
+    mockUseFormsTranslation.mockReturnValue({ t: (key: string) => key });
+    mockGetUserOrganizationId.mockResolvedValue("org-1");
+
+    mockHandleModalClose.mockReturnValue(true);
+    mockHandleDiscard.mockImplementation(() => {});
+    mockHandleStay.mockImplementation(() => {});
+    mockHandleSaveAndExit.mockImplementation(async () => {});
+
+    mockUseModalNavigation.mockImplementation(() => ({
+      showGuard: false,
+      message: "guard",
+      handleModalClose: mockHandleModalClose,
+      handleDiscardChanges: mockHandleDiscard,
+      handleStayOnModal: mockHandleStay,
+      handleSaveAndExit: mockHandleSaveAndExit,
+    }));
+  });
+
+  afterEach(() => {
+    mockSupabaseClient.from.mockImplementation(originalFromImplementation);
+  });
+
+  it("keeps the submit action disabled when no amount is provided", () => {
+    render(<AddPaymentDialog projectId="project-1" onPaymentAdded={jest.fn()} />);
+
+    expect(screen.getByTestId("footer-action-1")).toBeDisabled();
+    expect(toastMock.error).not.toHaveBeenCalled();
+  });
+
+  it("submits a new payment, resets the form, and notifies the parent callback", async () => {
+    const insertMock = jest.fn().mockResolvedValue({ error: null });
+
+    mockSupabaseClient.from.mockImplementation((table: string) => {
+      if (table === "payments") {
+        return { insert: insertMock } as any;
+      }
+      return originalFromImplementation(table);
+    });
+
+    const onPaymentAdded = jest.fn();
+
+    render(<AddPaymentDialog projectId="project-42" onPaymentAdded={onPaymentAdded} />);
+
+    fireEvent.change(screen.getByLabelText(/payments.amount_try/i), { target: { value: "123.45" } });
+    fireEvent.change(screen.getByLabelText(/payments.description/i), { target: { value: "Booking deposit" } });
+
+    fireEvent.click(screen.getByTestId("footer-action-1"));
+
+    await waitFor(() => {
+      expect(insertMock).toHaveBeenCalled();
+    });
+
+    expect(insertMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        project_id: "project-42",
+        user_id: "user-1",
+        organization_id: "org-1",
+        amount: 123.45,
+        description: "Booking deposit",
+        status: "paid",
+        type: "manual",
+        date_paid: expect.any(String),
+      })
+    );
+
+    expect(toastMock.success).toHaveBeenCalledWith("payments.payment_added_success");
+    expect(onPaymentAdded).toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect((screen.getByLabelText(/payments.amount_try/i) as HTMLInputElement).value).toBe("");
+      expect((screen.getByLabelText(/payments.description/i) as HTMLTextAreaElement).value).toBe("");
+    });
+  });
+
+  it("omits the paid date when the status is switched to due and closes cleanly when dirty close succeeds", async () => {
+    const insertMock = jest.fn().mockResolvedValue({ error: null });
+
+    mockSupabaseClient.from.mockImplementation((table: string) => {
+      if (table === "payments") {
+        return { insert: insertMock } as any;
+      }
+      return {} as any;
+    });
+
+    render(<AddPaymentDialog projectId="project-1" onPaymentAdded={jest.fn()} />);
+
+    fireEvent.change(screen.getByLabelText(/payments.amount_try/i), { target: { value: "200" } });
+    fireEvent.change(screen.getByTestId("status-select"), { target: { value: "due" } });
+
+    expect(screen.queryByTestId("calendar-trigger")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("footer-action-1"));
+
+    await waitFor(() => {
+      expect(insertMock).toHaveBeenCalled();
+    });
+
+    expect(insertMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "due",
+        date_paid: null,
+      })
+    );
+
+    fireEvent.change(screen.getByLabelText(/payments.amount_try/i), { target: { value: "75" } });
+
+    fireEvent.click(screen.getByTestId("dirty-close"));
+
+    expect(mockHandleModalClose).toHaveBeenCalled();
+    await waitFor(() => {
+      expect((screen.getByLabelText(/payments.amount_try/i) as HTMLInputElement).value).toBe("");
+    });
+  });
+});

--- a/src/components/__tests__/EditLeadDialog.test.tsx
+++ b/src/components/__tests__/EditLeadDialog.test.tsx
@@ -1,0 +1,276 @@
+import type { ComponentProps } from "react";
+import { fireEvent, render, screen, waitFor } from "@/utils/testUtils";
+import { EditLeadDialog } from "../EditLeadDialog";
+import { mockSupabaseClient } from "@/utils/testUtils";
+import { useI18nToast } from "@/lib/toastHelpers";
+import { useModalNavigation } from "@/hooks/useModalNavigation";
+
+jest.mock("@/integrations/supabase/client", () => ({
+  supabase: mockSupabaseClient,
+}));
+
+jest.mock("@/lib/toastHelpers", () => ({
+  useI18nToast: jest.fn(),
+}));
+
+jest.mock("@/hooks/useModalNavigation", () => ({
+  useModalNavigation: jest.fn(),
+}));
+
+jest.mock("@/components/ui/app-sheet-modal", () => ({
+  AppSheetModal: ({
+    title,
+    dirty,
+    children,
+    footerActions = [],
+    onDirtyClose,
+  }: any) => (
+    <div data-testid="app-sheet-modal" data-title={title} data-dirty={dirty ? "dirty" : "clean"}>
+      {children}
+      {footerActions.map((action: any, index: number) => (
+        <button
+          key={index}
+          data-testid={`footer-action-${index}`}
+          disabled={action.disabled}
+          onClick={action.onClick}
+        >
+          {action.label}
+        </button>
+      ))}
+      <button type="button" data-testid="dirty-close" onClick={() => onDirtyClose?.()}>
+        close-modal
+      </button>
+    </div>
+  ),
+}));
+
+jest.mock("@/components/ui/select", () => ({
+  Select: ({ value, onValueChange, children }: any) => (
+    <select data-testid="status-select" value={value} onChange={(event) => onValueChange(event.target.value)}>
+      {children}
+    </select>
+  ),
+  SelectTrigger: () => null,
+  SelectValue: () => null,
+  SelectContent: ({ children }: any) => <>{children}</>,
+  SelectItem: ({ value, children }: any) => (
+    <option value={value}>{typeof children === "string" ? children : value}</option>
+  ),
+}));
+
+jest.mock("../settings/NavigationGuardDialog", () => ({
+  NavigationGuardDialog: ({ open, message, onDiscard, onStay }: any) =>
+    open ? (
+      <div data-testid="navigation-guard">
+        <p>{message}</p>
+        <button onClick={onStay}>stay</button>
+        <button onClick={onDiscard}>discard</button>
+      </div>
+    ) : null,
+}));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const toastMock = {
+  success: jest.fn(),
+  error: jest.fn(),
+};
+
+const mockHandleModalClose = jest.fn();
+const mockHandleDiscard = jest.fn();
+const mockHandleStay = jest.fn();
+
+const mockUseModalNavigation = useModalNavigation as jest.Mock;
+const mockUseI18nToast = useI18nToast as jest.Mock;
+
+const lead = {
+  id: "lead-1",
+  name: "Taylor",
+  email: "taylor@example.com",
+  phone: "+1234567890",
+  notes: "Initial notes",
+  status: "New",
+};
+
+const statuses = [
+  { id: "status-1", name: "New", color: "#ff0", is_system_final: false },
+  { id: "status-2", name: "In Progress", color: "#0ff", is_system_final: false },
+];
+
+const createStatusFetch = () => {
+  const order = jest.fn().mockResolvedValue({ data: statuses, error: null });
+  const select = jest.fn().mockReturnValue({ order });
+  return { select, order };
+};
+
+const createDefaultFromResponse = () => ({
+  select: jest.fn().mockReturnThis(),
+  insert: jest.fn().mockReturnThis(),
+  update: jest.fn().mockReturnThis(),
+  delete: jest.fn().mockReturnThis(),
+  eq: jest.fn().mockReturnThis(),
+  in: jest.fn().mockReturnThis(),
+  order: jest.fn().mockReturnThis(),
+  limit: jest.fn().mockReturnThis(),
+  single: jest.fn(),
+});
+
+const originalFromImplementation = (mockSupabaseClient.from.getMockImplementation() || ((table: string) => createDefaultFromResponse())) as (
+  table: string
+) => any;
+
+describe("EditLeadDialog", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    if (originalFromImplementation) {
+      mockSupabaseClient.from.mockImplementation(originalFromImplementation);
+    }
+    mockSupabaseClient.from.mockClear();
+    mockUseI18nToast.mockReturnValue(toastMock);
+
+    mockHandleModalClose.mockReturnValue(true);
+    mockHandleDiscard.mockImplementation(() => {});
+    mockHandleStay.mockImplementation(() => {});
+
+    mockUseModalNavigation.mockImplementation(() => ({
+      showGuard: false,
+      message: "guard",
+      handleModalClose: mockHandleModalClose,
+      handleDiscardChanges: mockHandleDiscard,
+      handleStayOnModal: mockHandleStay,
+    }));
+  });
+
+  afterEach(() => {
+    if (originalFromImplementation) {
+      mockSupabaseClient.from.mockImplementation(originalFromImplementation);
+    }
+  });
+
+  it("returns null when no lead is provided", () => {
+    const { queryByTestId } = render(
+      <EditLeadDialog lead={null} open={true} onOpenChange={jest.fn()} onLeadUpdated={jest.fn()} />
+    );
+
+    expect(queryByTestId("app-sheet-modal")).toBeNull();
+  });
+
+  const renderDialog = (override: Partial<ComponentProps<typeof EditLeadDialog>> = {}) => {
+    const defaultProps = {
+      lead,
+      open: true,
+      onOpenChange: jest.fn(),
+      onLeadUpdated: jest.fn(),
+    } satisfies ComponentProps<typeof EditLeadDialog>;
+
+    return render(<EditLeadDialog {...defaultProps} {...override} />);
+  };
+
+  const arrangeSupabaseMocks = () => {
+    const { select } = createStatusFetch();
+    const updateMock = jest.fn().mockReturnValue({ eq: jest.fn().mockResolvedValue({ error: null }) });
+
+    mockSupabaseClient.from.mockImplementation((table: string) => {
+      if (table === "lead_statuses") {
+        return { select } as any;
+      }
+      if (table === "leads") {
+        return { update: updateMock } as any;
+      }
+      return originalFromImplementation ? originalFromImplementation(table) : ({} as any);
+    });
+
+    return { select, updateMock };
+  };
+
+  it("prefills fields with the current lead data", async () => {
+    const { select } = arrangeSupabaseMocks();
+
+    renderDialog();
+
+    await waitFor(() => {
+      expect(select).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("status-select")).toHaveValue("New");
+    });
+
+    expect(screen.getByLabelText(/labels.name/i)).toHaveValue("Taylor");
+    expect(screen.getByLabelText(/labels.email/i)).toHaveValue("taylor@example.com");
+    expect(screen.getByLabelText(/labels.notes/i)).toHaveValue("Initial notes");
+    expect(screen.getByTestId("status-select")).toHaveValue("New");
+  });
+
+  it("updates the lead and forwards callbacks on submit", async () => {
+    const { updateMock } = arrangeSupabaseMocks();
+
+    const onOpenChange = jest.fn();
+    const onLeadUpdated = jest.fn();
+
+    renderDialog({ onOpenChange, onLeadUpdated });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("status-select")).toHaveValue("New");
+    });
+
+    fireEvent.change(screen.getByLabelText(/labels.name/i), { target: { value: "Updated" } });
+    fireEvent.change(screen.getByLabelText(/labels.email/i), { target: { value: "new@example.com" } });
+    fireEvent.change(screen.getByTestId("status-select"), { target: { value: "In Progress" } });
+
+    fireEvent.click(screen.getByTestId("footer-action-1"));
+
+    await waitFor(() => {
+      expect(updateMock).toHaveBeenCalled();
+    });
+
+    expect(updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "Updated",
+        email: "new@example.com",
+        status: "In Progress",
+        status_id: "status-2",
+      })
+    );
+
+    expect(toastMock.success).toHaveBeenCalledWith("forms:messages.leadUpdateSuccess");
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onLeadUpdated).toHaveBeenCalled();
+  });
+
+  it("keeps the save action disabled when the name is empty", async () => {
+    const { updateMock } = arrangeSupabaseMocks();
+
+    renderDialog();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("status-select")).toHaveValue("New");
+    });
+
+    fireEvent.change(screen.getByLabelText(/labels.name/i), { target: { value: " " } });
+
+    expect(screen.getByTestId("footer-action-1")).toBeDisabled();
+    expect(toastMock.error).not.toHaveBeenCalled();
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it("respects the navigation guard when attempting to close with unsaved changes", async () => {
+    arrangeSupabaseMocks();
+
+    renderDialog();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("status-select")).toHaveValue("New");
+    });
+
+    fireEvent.change(screen.getByLabelText(/labels.name/i), { target: { value: "Changed" } });
+
+    fireEvent.click(screen.getByTestId("dirty-close"));
+
+    expect(mockHandleModalClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/__tests__/EditPaymentDialog.test.tsx
+++ b/src/components/__tests__/EditPaymentDialog.test.tsx
@@ -1,0 +1,304 @@
+import { fireEvent, render, screen, waitFor } from "@/utils/testUtils";
+import { EditPaymentDialog } from "../EditPaymentDialog";
+import { mockSupabaseClient } from "@/utils/testUtils";
+import { useI18nToast } from "@/lib/toastHelpers";
+import { useFormsTranslation } from "@/hooks/useTypedTranslation";
+import { useModalNavigation } from "@/hooks/useModalNavigation";
+
+jest.mock("@/integrations/supabase/client", () => ({
+  supabase: mockSupabaseClient,
+}));
+
+jest.mock("@/lib/toastHelpers", () => ({
+  useI18nToast: jest.fn(),
+}));
+
+jest.mock("@/hooks/useTypedTranslation", () => ({
+  useFormsTranslation: jest.fn(),
+}));
+
+jest.mock("@/hooks/useModalNavigation", () => ({
+  useModalNavigation: jest.fn(),
+}));
+
+jest.mock("@/components/ui/app-sheet-modal", () => ({
+  AppSheetModal: ({
+    title,
+    dirty,
+    children,
+    footerActions = [],
+    onDirtyClose,
+  }: any) => (
+    <div data-testid="app-sheet-modal" data-title={title} data-dirty={dirty ? "dirty" : "clean"}>
+      {children}
+      {footerActions.map((action: any, index: number) => (
+        <button
+          key={index}
+          data-testid={`footer-action-${index}`}
+          disabled={action.disabled}
+          onClick={action.onClick}
+        >
+          {action.label}
+        </button>
+      ))}
+      <button type="button" data-testid="dirty-close" onClick={() => onDirtyClose?.()}>
+        close-modal
+      </button>
+    </div>
+  ),
+}));
+
+jest.mock("@/components/ui/select", () => ({
+  Select: ({ value, onValueChange, children }: any) => (
+    <select data-testid="status-select" value={value} onChange={(event) => onValueChange(event.target.value)}>
+      {children}
+    </select>
+  ),
+  SelectTrigger: () => null,
+  SelectValue: () => null,
+  SelectContent: ({ children }: any) => <>{children}</>,
+  SelectItem: ({ value, children }: any) => (
+    <option value={value}>{typeof children === "string" ? children : value}</option>
+  ),
+}));
+
+jest.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: any) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: any) => <div>{children}</div>,
+  PopoverContent: ({ children }: any) => <div>{children}</div>,
+}));
+
+jest.mock("../settings/NavigationGuardDialog", () => ({
+  NavigationGuardDialog: ({ open, message, onDiscard, onStay }: any) =>
+    open ? (
+      <div data-testid="navigation-guard">
+        <p>{message}</p>
+        <button onClick={onStay}>stay</button>
+        <button onClick={onDiscard}>discard</button>
+      </div>
+    ) : null,
+}));
+
+jest.mock("@/components/ui/calendar", () => ({
+  Calendar: ({ onSelect }: any) => (
+    <button data-testid="calendar" onClick={() => onSelect(new Date("2024-01-05T00:00:00Z"))}>
+      pick-date
+    </button>
+  ),
+}));
+
+jest.mock("@/lib/utils", () => ({
+  ...jest.requireActual("@/lib/utils"),
+  getDateFnsLocale: jest.fn(() => undefined),
+  cn: (...classes: string[]) => classes.filter(Boolean).join(" "),
+}));
+
+const toastMock = {
+  success: jest.fn(),
+  error: jest.fn(),
+};
+
+const mockHandleModalClose = jest.fn();
+const mockHandleDiscard = jest.fn();
+const mockHandleStay = jest.fn();
+
+const mockUseModalNavigation = useModalNavigation as jest.Mock;
+const mockUseI18nToast = useI18nToast as jest.Mock;
+const mockUseFormsTranslation = useFormsTranslation as jest.Mock;
+
+const basePayment = {
+  id: "payment-1",
+  project_id: "project-9",
+  amount: 100,
+  description: "Deposit",
+  status: "paid" as const,
+  date_paid: "2024-01-01",
+  created_at: "2024-01-01T00:00:00Z",
+  type: "manual" as const,
+};
+
+const createDefaultFromResponse = () => ({
+  select: jest.fn().mockReturnThis(),
+  insert: jest.fn().mockReturnThis(),
+  update: jest.fn().mockReturnThis(),
+  delete: jest.fn().mockReturnThis(),
+  eq: jest.fn().mockReturnThis(),
+  in: jest.fn().mockReturnThis(),
+  order: jest.fn().mockReturnThis(),
+  limit: jest.fn().mockReturnThis(),
+  single: jest.fn(),
+});
+
+const originalFromImplementation = (mockSupabaseClient.from.getMockImplementation() || ((table: string) => createDefaultFromResponse())) as (
+  table: string
+) => any;
+
+describe("EditPaymentDialog", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    if (originalFromImplementation) {
+      mockSupabaseClient.from.mockImplementation(originalFromImplementation);
+    }
+    mockSupabaseClient.from.mockClear();
+    mockUseI18nToast.mockReturnValue(toastMock);
+    mockUseFormsTranslation.mockReturnValue({ t: (key: string) => key });
+
+    mockHandleModalClose.mockReturnValue(true);
+    mockHandleDiscard.mockImplementation(() => {});
+    mockHandleStay.mockImplementation(() => {});
+
+    mockUseModalNavigation.mockImplementation(() => ({
+      showGuard: false,
+      message: "guard",
+      handleModalClose: mockHandleModalClose,
+      handleDiscardChanges: mockHandleDiscard,
+      handleStayOnModal: mockHandleStay,
+    }));
+  });
+
+  afterEach(() => {
+    if (originalFromImplementation) {
+      mockSupabaseClient.from.mockImplementation(originalFromImplementation);
+    }
+  });
+
+  it("returns null when no payment is provided", () => {
+    const { queryByTestId } = render(
+      <EditPaymentDialog payment={null} open={true} onOpenChange={jest.fn()} onPaymentUpdated={jest.fn()} />
+    );
+
+    expect(queryByTestId("app-sheet-modal")).toBeNull();
+  });
+
+  it("pre-fills form fields from the provided payment", () => {
+    render(
+      <EditPaymentDialog
+        payment={basePayment}
+        open={true}
+        onOpenChange={jest.fn()}
+        onPaymentUpdated={jest.fn()}
+      />
+    );
+
+    expect(screen.getByLabelText(/edit_payment.amount_try/i)).toHaveDisplayValue("100");
+    expect(screen.getByLabelText(/edit_payment.description/i)).toHaveValue("Deposit");
+    expect(screen.getByTestId("status-select")).toHaveValue("paid");
+  });
+
+  it("updates a manual payment and closes when submission succeeds", async () => {
+    const updateMock = jest.fn().mockReturnValue({ eq: jest.fn().mockResolvedValue({ error: null }) });
+    mockSupabaseClient.from.mockImplementation((table: string) => {
+      if (table === "payments") {
+        return { update: updateMock } as any;
+      }
+      return originalFromImplementation ? originalFromImplementation(table) : ({} as any);
+    });
+
+    const onOpenChange = jest.fn();
+    const onPaymentUpdated = jest.fn();
+
+    render(
+      <EditPaymentDialog
+        payment={basePayment}
+        open={true}
+        onOpenChange={onOpenChange}
+        onPaymentUpdated={onPaymentUpdated}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText(/edit_payment.amount_try/i), { target: { value: "150" } });
+    fireEvent.change(screen.getByLabelText(/edit_payment.description/i), { target: { value: "Updated" } });
+
+    fireEvent.click(screen.getByTestId("footer-action-1"));
+
+    await waitFor(() => {
+      expect(updateMock).toHaveBeenCalled();
+    });
+
+    expect(updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: 150,
+        description: "Updated",
+        status: "paid",
+        date_paid: expect.any(String),
+      })
+    );
+
+    expect(toastMock.success).toHaveBeenCalledWith("edit_payment.payment_updated");
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onPaymentUpdated).toHaveBeenCalled();
+  });
+
+  it("updates base price on related project when editing a base payment", async () => {
+    const updatePaymentMock = jest.fn().mockReturnValue({ eq: jest.fn().mockResolvedValue({ error: null }) });
+    const updateProjectMock = jest.fn().mockReturnValue({ eq: jest.fn().mockResolvedValue({ error: null }) });
+
+    mockSupabaseClient.from.mockImplementation((table: string) => {
+      if (table === "payments") {
+        return { update: updatePaymentMock } as any;
+      }
+      if (table === "projects") {
+        return { update: updateProjectMock } as any;
+      }
+      return {} as any;
+    });
+
+    render(
+      <EditPaymentDialog
+        payment={{ ...basePayment, type: "base_price" as const }}
+        open={true}
+        onOpenChange={jest.fn()}
+        onPaymentUpdated={jest.fn()}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText(/edit_payment.amount_try/i), { target: { value: "250" } });
+    fireEvent.click(screen.getByTestId("footer-action-1"));
+
+    await waitFor(() => {
+      expect(updatePaymentMock).toHaveBeenCalled();
+    });
+
+    expect(updateProjectMock).toHaveBeenCalledWith(
+      expect.objectContaining({ base_price: 250 })
+    );
+  });
+
+  it("switches to due status, removes the paid date, and respects dirty close flow", async () => {
+    const updateMock = jest.fn().mockReturnValue({ eq: jest.fn().mockResolvedValue({ error: null }) });
+
+    mockSupabaseClient.from.mockImplementation((table: string) => {
+      if (table === "payments") {
+        return { update: updateMock } as any;
+      }
+      return {} as any;
+    });
+
+    render(
+      <EditPaymentDialog
+        payment={basePayment}
+        open={true}
+        onOpenChange={jest.fn()}
+        onPaymentUpdated={jest.fn()}
+      />
+    );
+
+    fireEvent.change(screen.getByTestId("status-select"), { target: { value: "due" } });
+
+    fireEvent.click(screen.getByTestId("footer-action-1"));
+
+    await waitFor(() => {
+      expect(updateMock).toHaveBeenCalled();
+    });
+
+    expect(updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "due",
+        date_paid: null,
+      })
+    );
+
+    fireEvent.click(screen.getByTestId("dirty-close"));
+    expect(mockHandleModalClose).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for the legacy Add/Edit Payment dialogs, covering disabled states, payload shaping, due-date handling, and navigation guard interactions
- add unit tests for the legacy Add/Edit Lead dialogs, validating sanitized inserts, status lookups, prefills, and dirty-close behavior
- update docs/unit-testing-plan.md with new coverage rows, refreshed progress snapshot, and an iteration log entry

## Testing
- `npm test -- AddPaymentDialog.test.tsx EditPaymentDialog.test.tsx AddLeadDialog.test.tsx EditLeadDialog.test.tsx`
- `npm test -- --runInBand` *(fails: CalendarMonthView duplicate text query, Services/Projects settings expectations, and tutorial fake timers due to pre-existing suite issues)*

------
https://chatgpt.com/codex/tasks/task_e_68fd1ab9f5a0832199ec9ca7f3822c57