### PR TITLE
Add coverage for project services and activity sections

### DIFF
--- a/docs/unit-testing-plan.md
+++ b/docs/unit-testing-plan.md
@@ -39,10 +39,10 @@
 | Core Libraries & Helpers | 13 | 13 | 100% |
 | Services & Data Access | 5 | 5 | 100% |
 | Contexts & Hooks | 27 | 27 | 100% |
-| UI Components & Pages | 75 | 77 | 97% |
+| UI Components & Pages | 77 | 77 | 100% |
 | UI Primitives & Shared Components | 18 | 18 | 100% |
 | Supabase Edge Functions & Automation | 9 | 9 | 100% |
-| **Overall** | **147** | **149** | **99%** |
+| **Overall** | **149** | **149** | **100%** |
 
 ### Core Libraries & Helpers
 | Area | File(s) | What to Cover | Priority | Status | Notes |
@@ -145,6 +145,8 @@
 | Session status badge | `src/components/SessionStatusBadge.tsx` | Lifecycle color mapping, accessible labels | Low | Done | Covered by `src/components/__tests__/SessionStatusBadge.test.tsx` (loading badge + editable dropdown updates). |
 | Session banner | `src/components/SessionBanner.tsx` | Planned vs post-session messaging, action availability, translation keys | Medium | Done | Covered by `src/components/__tests__/SessionBanner.test.tsx` validating planned details, edit gating, and delete callbacks. |
 | Project payments section | `src/components/ProjectPaymentsSection.tsx` | Summary cards, refresh triggers, empty states | Medium | Done | Covered by `src/components/__tests__/ProjectPaymentsSection.test.tsx` for metrics, refresh callback, and empty state. |
+| Project services section | `src/components/ProjectServicesSection.tsx` | Supabase fetch, edit mode interactions, save + toast feedback | Medium | Done | Covered by `src/components/__tests__/ProjectServicesSection.test.tsx` validating data hydration, picker wiring, and save success toasts. |
+| Project activity section | `src/components/ProjectActivitySection.tsx` | Activity load, validation guardrails, reminder saves, completion toggles | Medium | Done | Covered by `src/components/__tests__/ProjectActivitySection.test.tsx` asserting fetch rendering, destructive validation toasts, save flow, and completion updates. |
 | Sessions section surface | `src/components/SessionsSection.tsx` | Tab filtering, sorting integration, quick actions | Medium | Done | Covered by `src/components/__tests__/SessionsSection.test.tsx` for skeleton state, empty CTA wiring, and banner/sheet interactions. |
 | Enhanced sessions section | `src/components/EnhancedSessionsSection.tsx` | Multi-column layout, performance instrumentation | Medium | Done | Covered by `src/components/__tests__/EnhancedSessionsSection.test.tsx` verifying lifecycle sorting, count badge, and click wiring. |
 | Unified client details | `src/components/UnifiedClientDetails.tsx` | Conditional rendering of contact info, copy buttons | Low | Done | Covered by `src/components/__tests__/UnifiedClientDetails.test.tsx` validating quick actions, custom field display, navigation hooks, and validation toasts. |
@@ -304,6 +306,7 @@ _Statuses_: `Not started`, `In progress`, `Blocked`, `Ready for review`, `Done`.
 | 2025-11-13 | Codex | Added calendar component coverage | Added `src/components/calendar/__tests__/CalendarDay.test.tsx`, `CalendarDayView.test.tsx`, `CalendarMonthView.test.tsx`, `CalendarWeek.test.tsx`, `CalendarSkeleton.test.tsx`, and `CalendarErrorBoundary.test.tsx` to cover mobile/day/month/week interactions, skeleton scaffolds, and error recovery flows | Next: Explore coverage for calendar virtualization performance metrics and touch gesture edge cases |
 | 2025-11-14 | Codex | Added reminder details page coverage | Added `src/pages/__tests__/ReminderDetails.test.tsx` to validate reminder stats, fetch error toasts, completion toggles, navigation, and project dialog fetches | Keep an eye on future reminder reschedule flows or provider refactors |
 | 2025-11-15 | Codex | Added legacy payment & lead dialog coverage | Added `src/components/__tests__/AddPaymentDialog.test.tsx`, `EditPaymentDialog.test.tsx`, `AddLeadDialog.test.tsx`, and `EditLeadDialog.test.tsx`; refreshed progress snapshot totals | Monitor dialog flows if currency/localization options expand or navigation guard messaging changes |
+| 2025-11-16 | Codex | Added project services and activity coverage | Added `src/components/__tests__/ProjectServicesSection.test.tsx` and `ProjectActivitySection.test.tsx` to validate services edit/save flows, validation toasts, reminders, and completion updates | Watch for future service pricing changes or activity form enhancements |
 
 ## Maintenance Rules of Thumb
 - Treat this file like the single source of truth for unit testing status—update it in the same PR as any test additions or strategy changes.

--- a/src/components/__tests__/ProjectActivitySection.test.tsx
+++ b/src/components/__tests__/ProjectActivitySection.test.tsx
@@ -1,0 +1,220 @@
+import { render, screen, fireEvent, waitFor } from "@/utils/testUtils";
+import { ProjectActivitySection } from "@/components/ProjectActivitySection";
+import { supabase } from "@/integrations/supabase/client";
+import { getUserOrganizationId } from "@/lib/organizationUtils";
+import { toast } from "@/hooks/use-toast";
+
+jest.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    from: jest.fn(),
+    auth: {
+      getUser: jest.fn()
+    }
+  }
+}));
+
+jest.mock("@/hooks/use-toast", () => ({
+  toast: jest.fn()
+}));
+
+jest.mock("@/lib/organizationUtils", () => ({
+  getUserOrganizationId: jest.fn()
+}));
+
+jest.mock("@/components/shared/ActivityForm", () => ({
+  ActivityForm: ({ onSubmit, placeholder }: any) => (
+    <div>
+      <p>{placeholder}</p>
+      <button onClick={() => onSubmit("", false)}>submit-empty</button>
+      <button onClick={() => onSubmit("New note", false)}>submit-note</button>
+      <button onClick={() => onSubmit("Reminder detail", true, "2025-01-01T10:00")}>submit-reminder</button>
+    </div>
+  )
+}));
+
+jest.mock("@/components/shared/ActivityTimeline", () => ({
+  ActivityTimeline: ({ activities, onToggleCompletion }: any) => (
+    <div>
+      {activities.map((activity: any) => (
+        <div key={activity.id}>
+          <span>{activity.content}</span>
+          <button onClick={() => onToggleCompletion(activity.id, !activity.completed)}>
+            toggle-{activity.id}
+          </button>
+        </div>
+      ))}
+    </div>
+  )
+}));
+
+const translations: Record<string, string> = {
+  "projectDetails.activities.title": "Project activity",
+  "projectDetails.activities.placeholder": "Log a note",
+  "validation.required_field": "Required",
+  "validation.content_required": "Content required",
+  "validation.datetime_required_for_reminders": "Reminder needs a date",
+  "success.saved": "Saved",
+  "activity.note": "Note",
+  "activity.reminder": "Reminder",
+  "activity.added_to_project": "added to project",
+  "activity.task_completed": "Task completed",
+  "activity.task_incomplete": "Task incomplete",
+  "activity.task_status_updated": "Task status updated",
+  "activity.error_updating_task": "Error updating task",
+  "error.generic": "Something went wrong"
+};
+
+jest.mock("@/hooks/useTypedTranslation", () => ({
+  useFormsTranslation: () => ({
+    t: (key: string) => translations[key] ?? key
+  })
+}));
+
+describe("ProjectActivitySection", () => {
+  const toastSpy = toast as jest.Mock;
+  const insertSpy = jest.fn();
+  const updateSpy = jest.fn();
+  let activitiesResponse: any[] = [];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    insertSpy.mockReset();
+    updateSpy.mockReset();
+    toastSpy.mockReset();
+
+    activitiesResponse = [
+      {
+        id: "act-1",
+        type: "note",
+        content: "Kickoff call",
+        created_at: "2025-01-01",
+        lead_id: "lead-1",
+        project_id: "project-1",
+        user_id: "user-1",
+        completed: false
+      }
+    ];
+
+    insertSpy.mockImplementation(() => ({
+      select: jest.fn(() => ({
+        single: jest.fn().mockResolvedValue({ data: { id: "new-activity" }, error: null })
+      }))
+    }));
+
+    updateSpy.mockImplementation(() => ({
+      eq: jest.fn().mockResolvedValue({ error: null })
+    }));
+
+    (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+      data: { user: { id: "user-123" } }
+    });
+
+    (getUserOrganizationId as jest.Mock).mockResolvedValue("org-123");
+
+    (supabase.from as jest.Mock).mockImplementation((table: string) => {
+      if (table === "activities") {
+        return {
+          select: jest.fn(() => ({
+            eq: jest.fn(() => ({
+              eq: jest.fn(() => ({
+                order: jest.fn().mockImplementation(() =>
+                  Promise.resolve({ data: activitiesResponse, error: null })
+                )
+              }))
+            }))
+          })),
+          insert: insertSpy,
+          update: updateSpy
+        };
+      }
+      return {};
+    });
+  });
+
+  function renderSection(onActivityUpdated = jest.fn()) {
+    return render(
+      <ProjectActivitySection
+        projectId="project-1"
+        leadId="lead-1"
+        leadName="Jane Doe"
+        projectName="Wedding"
+        onActivityUpdated={onActivityUpdated}
+      />
+    );
+  }
+
+  test("renders fetched activities", async () => {
+    renderSection();
+
+    expect(await screen.findByText("Kickoff call")).toBeInTheDocument();
+    expect(screen.getByText("Log a note")).toBeInTheDocument();
+  });
+
+  test("validates empty submission", async () => {
+    renderSection();
+    await screen.findByText("Kickoff call");
+
+    fireEvent.click(screen.getByText("submit-empty"));
+
+    expect(toastSpy).toHaveBeenCalledWith({
+      title: "Required",
+      description: "Content required",
+      variant: "destructive"
+    });
+  });
+
+  test("saves reminder and toggles completion", async () => {
+    const updatedSpy = jest.fn();
+    renderSection(updatedSpy);
+
+    await screen.findByText("Kickoff call");
+
+    activitiesResponse = [
+      ...activitiesResponse,
+      {
+        id: "act-2",
+        type: "reminder",
+        content: "Reminder detail",
+        created_at: "2025-01-02",
+        lead_id: "lead-1",
+        project_id: "project-1",
+        user_id: "user-123",
+        completed: false
+      }
+    ];
+
+    fireEvent.click(screen.getByText("submit-reminder"));
+
+    await waitFor(() => {
+      expect(insertSpy).toHaveBeenCalledWith({
+        user_id: "user-123",
+        lead_id: "lead-1",
+        project_id: "project-1",
+        type: "reminder",
+        content: "Reminder detail",
+        reminder_date: "2025-01-01",
+        reminder_time: "10:00",
+        organization_id: "org-123"
+      });
+    });
+
+    await waitFor(() => expect(toastSpy).toHaveBeenCalledWith({
+      title: "Saved",
+      description: "Reminder added to project.",
+      variant: undefined
+    }));
+
+    expect(updatedSpy).toHaveBeenCalled();
+    expect(await screen.findByText("Reminder detail")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("toggle-act-2"));
+
+    await waitFor(() => {
+      expect(updateSpy).toHaveBeenCalledWith({ completed: true });
+      expect(toastSpy).toHaveBeenCalledWith({
+        title: "Task completed",
+        description: "Task status updated"
+      });
+    });
+  });
+});

--- a/src/components/__tests__/ProjectServicesSection.test.tsx
+++ b/src/components/__tests__/ProjectServicesSection.test.tsx
@@ -1,0 +1,189 @@
+import { render, screen, waitFor, fireEvent } from "@/utils/testUtils";
+import { ProjectServicesSection } from "@/components/ProjectServicesSection";
+import { supabase } from "@/integrations/supabase/client";
+
+jest.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    from: jest.fn(),
+    auth: {
+      getUser: jest.fn()
+    },
+    rpc: jest.fn()
+  }
+}));
+
+const toastSuccess = jest.fn();
+
+jest.mock("@/lib/toastHelpers", () => ({
+  useI18nToast: () => ({
+    success: toastSuccess,
+    error: jest.fn()
+  })
+}));
+
+const translations: Record<string, string> = {
+  "services.title": "Services",
+  "services.add": "Add services",
+  "services.edit": "Edit services",
+  "services.selected_services": "Selected services",
+  "services.services_updated": "Services updated",
+  "services.cost": "Cost",
+  "services.selling": "Selling",
+  "projectDetails.services.emptyState": "No services yet",
+  "projectDetails.services.addHint": "Add services to get started",
+  "buttons.clearAll": "Clear All",
+  "common:actions.saving": "Saving",
+  "common:buttons.save": "Save",
+  "common:buttons.cancel": "Cancel"
+};
+
+jest.mock("@/hooks/useTypedTranslation", () => ({
+  useFormsTranslation: () => ({
+    t: (key: string) => translations[key] ?? key
+  })
+}));
+
+jest.mock("@/components/ServicePicker", () => ({
+  ServicePicker: ({ value, onChange, isLoading, error, onRetry }: any) => (
+    <div data-testid="service-picker">
+      <div data-testid="service-picker-value">{value.join(",")}</div>
+      {isLoading && <span>Loading services…</span>}
+      {error && (
+        <>
+          <span>{error}</span>
+          <button onClick={onRetry}>Retry</button>
+        </>
+      )}
+      <button onClick={() => onChange(["svc-2"]) }>Choose second</button>
+    </div>
+  )
+}));
+
+const mockProjectServices = [
+  {
+    services: {
+      id: "svc-1",
+      name: "Portrait Session",
+      category: "Photography",
+      cost_price: 50,
+      selling_price: 150
+    }
+  }
+];
+
+const availableServices = [
+  {
+    id: "svc-1",
+    name: "Portrait Session",
+    category: "Photography",
+    cost_price: 50,
+    selling_price: 150
+  },
+  {
+    id: "svc-2",
+    name: "Wedding Package",
+    category: "Photography",
+    cost_price: 200,
+    selling_price: 450
+  }
+];
+
+const insertSpy = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+    data: { user: { id: "user-1" } }
+  });
+
+  (supabase.rpc as jest.Mock).mockResolvedValue({ data: "org-1" });
+
+  insertSpy.mockResolvedValue({ error: null });
+
+  (supabase.from as jest.Mock).mockImplementation((table: string) => {
+    if (table === "project_services") {
+      return {
+        select: jest.fn(() => ({
+          eq: jest.fn().mockResolvedValue({ data: mockProjectServices, error: null })
+        })),
+        delete: jest.fn(() => ({
+          eq: jest.fn().mockResolvedValue({ error: null })
+        })),
+        insert: insertSpy
+      };
+    }
+
+    if (table === "services") {
+      return {
+        select: jest.fn(() => ({
+          eq: jest.fn(() => ({
+            order: jest.fn(() => ({
+              order: jest.fn().mockResolvedValue({ data: availableServices, error: null })
+            }))
+          }))
+        }))
+      };
+    }
+
+    return {};
+  });
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+function renderComponent(onServicesUpdated?: jest.Mock) {
+  return render(
+    <ProjectServicesSection projectId="project-1" onServicesUpdated={onServicesUpdated} />
+  );
+}
+
+test("renders fetched services and toggles edit mode", async () => {
+  renderComponent();
+
+  expect(await screen.findByText("Portrait Session")).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "Edit services" })).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole("button", { name: "Edit services" }));
+
+  expect(await screen.findByTestId("service-picker")).toBeInTheDocument();
+  expect(screen.getByTestId("service-picker-value").textContent).toBe("svc-1");
+
+  fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+  await waitFor(() => expect(screen.queryByTestId("service-picker")).not.toBeInTheDocument());
+  expect(screen.getByRole("button", { name: "Edit services" })).toBeInTheDocument();
+});
+
+test("saves updated services and shows success toast", async () => {
+  const updatedCallback = jest.fn();
+
+  renderComponent(updatedCallback);
+
+  await screen.findByText("Portrait Session");
+
+  fireEvent.click(screen.getByRole("button", { name: "Edit services" }));
+  const saveButton = await screen.findByRole("button", { name: "Save" });
+
+  fireEvent.click(screen.getByText("Choose second"));
+
+  fireEvent.click(saveButton);
+
+  await waitFor(() => {
+    expect(insertSpy).toHaveBeenCalledWith([
+      {
+        project_id: "project-1",
+        service_id: "svc-2",
+        user_id: "user-1"
+      }
+    ]);
+  });
+
+  await waitFor(() => expect(toastSuccess).toHaveBeenCalledWith("Services updated"));
+  expect(updatedCallback).toHaveBeenCalled();
+
+  await waitFor(() => expect(screen.queryByTestId("service-picker")).not.toBeInTheDocument());
+  expect(screen.getByRole("button", { name: "Edit services" })).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add ProjectServicesSection tests covering fetch, edit, and save flows
- add ProjectActivitySection tests for validation, reminders, and completion toggles
- update the unit-testing plan snapshot and log to reflect full UI component coverage

## Testing
- npm test -- ProjectServicesSection
- npm test -- ProjectActivitySection

------
https://chatgpt.com/codex/tasks/task_e_68fd206705fc832190e9ecdd3e40e1b9