### PR TITLE
Extend settings plan with tax & billing profile details

### DIFF
--- a/docs/services-and-packages-plan.md
+++ b/docs/services-and-packages-plan.md
@@ -11,22 +11,34 @@
   - Keep the settings UI familiar while surfacing the new grouping and required metadata.
   - Enable packages to compose multiple catalog items (base, add-ons) with clear totals.
   - Upgrade project flows to support the new line-item selector, ready for quantities and duplicates.
+  - Capture KDV (VAT) expectations per service so totals stay accurate whether prices are tax-inclusive or exclusive.
+  - Provide organization-level tax + billing defaults so new services/packages start with the right KDV mode, rate, and invoice identity.
 - **Constraints**
   - First iteration stays simple: no advanced pricing tiers or scheduling logic yet.
   - Respect current Supabase schema; any new columns or tables require coordination but aim for additive changes.
   - Avoid regressing existing catalog management or project creation during rollout—feature-flag where needed.
+  - Apply KDV exactly once per line item; avoid double-charging when composing packages or overriding prices downstream.
 
 ## Phase 1 — Reshape Service Catalog *(in progress)*
 - **Data design**
   - ✅ Added `service_type` + `is_people_based` to `services` (UI is consuming both the segmented filters and new dialogs).
   - ✅ Prepare migration + backfill script so existing rows pick the right type and staffing flag (`supabase/migrations/20251107120000_services_backfill_types.sql` drafted; QA + rollout checklist pending).
   - ✅ Decision: keep the `default_unit` column in the schema but defer exposing it in v1—line-item work will revisit once package quantity pickers land.
+  - 🚧 Introduce `vat_rate` (`numeric(5,2)`) and `price_includes_vat` (`boolean`, default `false`) on `services`, seeded from an organization-level default. Backfill existing services to `0%` so totals stay unchanged until users opt in.
+  - 🚧 Extend `organizations` (or companion `organization_settings`) with `tax_profile` jsonb capturing billing identity + default KDV settings, including migration/backfill using the existing single KDV field when present.
+- **Organization settings**
+  - 🚧 Add a **Tax & Billing** section under organization settings so owners can define defaults once and reuse them across services/packages.
+  - 🚧 Fields: legal entity toggle (`Şahıs` vs `Şirket`), company name, tax office, VKN/TCKN, optional billing address, default KDV rate %, and whether catalog prices include KDV by default.
+  - 🚧 Surface helper text clarifying that defaults only pre-fill new services/packages; existing records keep their stored values until edited.
 - **UI & UX**
   - ✅ Services settings now use the segmented control (coverage vs deliverable) and refreshed cards/dialog copy.
   - ✅ Dialogs expose the new fields only when relevant and include empty-state guidance.
+  - 🚧 Extend the service dialog pricing block with a "KDV" accordion: radio control for **Included in price** vs **Add on top** plus a numeric percentage input. Mirror copy in TR (`KDV fiyatın içinde` / `KDV ayrıca eklenecek`). Persist the choices to the new fields.
 - **Tech tasks**
   - ✅ Hooks/tests updated to return the new columns.
   - ⏳ Audit downstream consumers (packages, project flows, reports) to ensure they tolerate the richer payload.
+  - 🚧 Normalize KDV math helpers (`calculateVatPortion`, `applyVat`) so both settings and package builders share a single implementation. Ensure inclusive prices surface the tax amount separately without altering stored base price.
+  - 🚧 Extend `useOrganization` payload with `taxProfile` (entity type, names, identifiers, default `vatRate`, `vatMode`) sourced from the new settings screen. Ensure service/package forms hydrate from it while allowing per-item overrides.
 - **Output**
   - Catalog UI differentiates staffing vs deliverables; backfill + consumer audit remain before closing the phase.
 
@@ -34,13 +46,16 @@
 - **Catalog integration**
   - Update package dialogs to consume the enriched service data.
   - Introduce a simple bundle builder: select a base service, then add optional coverage/deliverable items.
+  - Pull `vat_rate` + `price_includes_vat` onto each line item so package totals reflect tax-inclusive vs exclusive items without double-counting.
 - **UX updates**
   - Show selected items as a list with grouping badges and individual prices; keep duplication disabled for now.
   - Provide a lightweight total calculator so users see package pricing clarity.
+  - Display KDV chips inline (e.g., `KDV %18 dahil` or `+%20 KDV`) and surface a summary row that breaks out subtotal, KDV total, and grand total.
 - **Tech tasks**
   - Share a new `ServiceLineItems` state shape (`serviceId`, `quantity?`, `unitPrice?`) even if quantity defaults to 1.
   - Ensure package previews in the wizard and project detail reuse this structure.
   - ✅ Update Supabase persistence to store the ordered list (`packages.line_items` jsonb) and mirror legacy add-ons until front-end migration lands.
+  - Extend the line item schema to `{ serviceId, quantity?, unitPrice?, vatRate, vatMode: 'included' | 'exclusive' }`, defaulting from the service record. Guard against adding organization-level KDV again at package submission.
 - **Output**
   - Packages reflect real-world combinations (base shoot + album + print pack) and seed the upcoming project flow updates.
 
@@ -64,6 +79,7 @@
   - Update help docs/tooltips describing coverage vs deliverable.
   - Expand Jest/UI tests to cover both service types and the new package builder interactions.
   - Maintain feature flags or staged rollout to prevent regressions during migration.
+  - Add QA scenarios for mixed KDV setups (all inclusive, all exclusive, and mixed) to ensure totals match manual calculations before launch.
 
 ## Tracking & Follow-ups
 - 🚧 Run and verify the new backfill migration (`supabase/migrations/20251107120000_services_backfill_types.sql`) before enabling the segmented UI for all orgs. *(pending QA/deployment)*

--- a/docs/settings-experience-plan.md
+++ b/docs/settings-experience-plan.md
@@ -46,7 +46,9 @@ Settings (src/pages/settings)
 │   ├── Packages (pricing cards + onboarding tutorial)
 │   └── Services Catalog (category cards)
 ├── Contracts (placeholder copy)
-├── Billing   (placeholder copy)
+├── Billing
+│   ├── Tax & Billing Profile (organization defaults for KDV + invoice identity)
+│   └── Payment Methods (future state / integrations)
 └── Danger Zone (destructive actions, password confirmation)
 
 Cross-cutting components:
@@ -143,6 +145,7 @@ Cross-cutting components:
 ### Phase 2 — Page Wave A (Foundation)
 - `[ ]` Profile: migrate to new sections, refine avatar/work hours layout, hook to shared uploader.
 - `[ ]` General: apply form + collection sections, add explicit save for branding/regional, unify social channels card, and wire anchor nav jump links per section.
+- `[ ]` Billing › Tax & Billing Profile: design the KDV + invoice identity form using `SettingsFormSection`, surface organization defaults (legal entity, company name, tax office, VKN/TCKN, billing address, default KDV mode + rate, e-Fatura readiness toggle), and provide inline helper text explaining how values cascade into services/packages and future invoicing.
 - `[ ]` Notifications: convert toggles to `SettingsToggleSection`, throttle fetches, add `Test` button alignment.
 - `[ ]` Ship translation updates and ensure tutorials overlay the refreshed layout.
 - `[ ]` Routing & breakpoints: route `/settings` to the mobile dashboard below `md`, ensure back navigation + compact spacing tokens apply across Profile/General/Notifications.
@@ -153,6 +156,13 @@ Cross-cutting components:
 - `[ ]` Services: standardize cards for session types/packages/services; consolidate onboarding surfaces.
 - `[ ]` Document data fetch policies (manual refresh vs. auto).
 - `[ ]` Extend anchor nav mapping and mobile back pattern to collection-heavy pages (Leads/Projects/Services) with sensible section groupings.
+
+### Phase 3.5 — Compliance & Billing Foundations
+- `[ ]` Persist organization tax profile via `useOrganizationSettings` with optimistic save + dirty state pill; ensure partial updates do not clear existing tax identifiers.
+- `[ ]` Add validation masks for TCKN/VKN (11-digit national ID vs 10-digit tax number) and guard rails for numeric KDV ranges (0–99.99%).
+- `[ ]` Surface audit log events (`settings_tax_profile_updated`) so finance tooling can track changes before e-Fatura integrations.
+- `[ ]` Store structured invoice address (`street`, `district`, `city`, `country`, `postalCode`) ready for electronic invoice payloads.
+- `[ ]` Document API contracts for downstream billing services (e.g., `POST /billing/profile/snapshot`) and expose a "Download billing profile" action for manual compliance exports.
 
 ### Phase 4 — Peripheral Pages & Cleanup
 - `[ ]` Danger Zone: apply danger block pattern, tighten copy, confirm double-confirm flow.
@@ -178,7 +188,7 @@ Cross-cutting components:
 | Projects | Statuses / Types / Session Statuses | [ ] | Drag reorder + inline defaults | Shared hook for status entities | Not Started | Do project status/type templates need to stay synced across teams or can users diverge freely? |
 | Services | Session Types / Packages / Services | [ ] | Multi-step onboarding alignment | Consolidate queries, lazy-load heavy dialogs | Not Started | Are packages expected to support multi-currency pricing in this release or remain single-currency? |
 | Contracts | Placeholder | [ ] | N/A (display card) | Static copy | Not Started | Should the placeholder point to upcoming in-product templates or route to external contract resources until builder ships? |
-| Billing | Placeholder | [ ] | N/A (display card) | Static copy | Not Started | Do we expose plan/usage details here now, or defer to finance portal messaging until billing revamp? |
+| Billing | Tax & Billing Profile / Payment Methods | [ ] | Explicit save with helper modals + audit log surface | Persist `taxProfile` jsonb, prepare payment method vault stub | Not Started | Which e-Fatura provider (if any) are we targeting first, and do we need multi-address support for branches? |
 | Danger Zone | Delete org | [ ] | Double confirm + password field | No auto-refetch | Not Started | Does org deletion require a grace period or approval workflow beyond the password confirmation flow? |
 
 > Update the table as work lands (check items, add Notes column if needed).


### PR DESCRIPTION
## Summary
- outline the dedicated Tax & Billing Profile section within the billing settings IA
- add roadmap tasks to design, persist, and validate organization-level KDV defaults and billing identity details
- update the billing checklist entry to reflect the new experience and downstream data strategy

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_690662eb080c832183123d19d0f80d38