### PR TITLE
Fix hoisted mocks and router setup in tests

### DIFF
--- a/src/pages/__tests__/TemplateBuilder.test.tsx
+++ b/src/pages/__tests__/TemplateBuilder.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { fireEvent, render, screen, waitFor } from "@/utils/testUtils";
+import * as ReactRouterDom from "react-router-dom";
 import TemplateBuilder from "../TemplateBuilder";
 import { mockSupabaseClient } from "@/utils/testUtils";
 import { useTemplateBuilder } from "@/hooks/useTemplateBuilder";
@@ -121,9 +122,10 @@ const baseTemplate = {
 describe("TemplateBuilder page", () => {
   beforeEach(() => {
     const navigateMock = jest.fn();
-    import * as ReactRouterDom from "react-router-dom";
     jest.spyOn(ReactRouterDom, "useNavigate").mockReturnValue(navigateMock);
-        jest.spyOn(ReactRouterDom, "useSearchParams").mockReturnValue([new URLSearchParams("id=template-1"), jest.fn()]);
+    jest
+      .spyOn(ReactRouterDom, "useSearchParams")
+      .mockReturnValue([new URLSearchParams("id=template-1"), jest.fn()]);
 
     mockSupabaseClient.from = jest.fn(() => ({
       select: jest.fn().mockReturnThis(),


### PR DESCRIPTION
## Summary
- mock the Supabase client and lazily-imported hooks in UpcomingSessions tests without hoisted variables, including a controllable organization ID helper
- inline the XLSX stubs and ensure session status mocks can be reset between tests
- load React Router helpers at the top of TemplateBuilder tests to avoid invalid dynamic imports

## Testing
- npm test -- --runTestsByPath src/pages/__tests__/UpcomingSessions.test.tsx
- npm test -- --runTestsByPath src/pages/__tests__/TemplateBuilder.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_690c31d07fe08321952a20e641bff71f